### PR TITLE
Implement ^FX and ^LH commands, add CLAUDE.md roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# Fabra
+
+An F# DSL for generating Zebra Programming Language (ZPL) labels.
+
+## Project layout
+
+- `Types.fs` — ZPL command domain types; each renders itself via `ToString()`.
+- `Label.fs` — the `Label` type with `static member` factory functions, the
+  internal `Render` module, and the public `ZPL.render` function.
+- `Examples/` — `.fsx` scripts plus their expected `.zpl` golden output.
+- `tests/Fabra.Tests/` — xUnit golden-file and rendering tests.
+
+## Build & test
+
+```
+dotnet build Fabra.sln -c Release
+dotnet test Fabra.sln
+```
+
+The golden tests assert the example labels render to the committed
+`Examples/*.zpl` files. If a rendering change is intentional, regenerate
+those files and review the diff before committing.
+
+## Adding a ZPL command
+
+Each command follows the same pattern:
+
+1. Add a domain type to `Types.fs` with a `ToString()` that emits the ZPL.
+2. Add a case to the `LabelElement` union.
+3. Add a `static member` factory to the `Label` type in `Label.fs`.
+4. Add a branch to the `Render.label` loop in `Label.fs`.
+5. Add a test in `tests/Fabra.Tests`.
+
+## ZPL command roadmap
+
+Fabra implements roughly 10 of the ~200 ZPL commands — the subset needed
+for simple static labels. Planned additions, ordered easy → hard:
+
+- [x] `^FX` — Comment. New `Comment` type; renders `^FX{text}^FS`.
+- [x] `^LH` — Label Home. New `LabelHome` record (x, y); renders `^LH{x},{y}`.
+- [ ] `^A` font selector — the `Text` type currently hardcodes font `0`
+      (`^A0`). Add a font parameter (`A`–`Z`, `0`–`9`) so other resident
+      fonts can be selected. Breaking change to the `Label.Text` factory.
+- [ ] `^FB` — Field Block (word-wrapped, multi-line text). New `FieldBlock`
+      type (width, max lines, line spacing, justification, hanging indent);
+      a modifier emitted before the `^FD` it applies to.
+- [ ] `^BQ` — QR Code. New `QrCode` type (orientation, model,
+      magnification, error correction, mask); renders `^BQ...` plus `^FD`.
+- [ ] `^GF` — Graphic Field (bitmap images). Largest item; needs an
+      image → monochrome-bitmap encoder. Phase 1: accept pre-encoded
+      `^GFA` ASCII-hex data. Phase 2: add the image-to-bitmap converter.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,14 @@ Each command follows the same pattern:
 4. Add a branch to the `Render.label` loop in `Label.fs`.
 5. Add a test in `tests/Fabra.Tests`.
 
+## Pull requests
+
+- Always request a GitHub Copilot review on a new pull request.
+- Evaluate each Copilot comment on its merits. Reject suggestions that
+  aren't useful or are incorrect, replying to the thread with a brief
+  reason (cite the ZPL spec where relevant). Apply the useful ones and
+  reply to the thread confirming the change.
+
 ## ZPL command roadmap
 
 Fabra implements roughly 10 of the ~200 ZPL commands — the subset needed

--- a/Label.fs
+++ b/Label.fs
@@ -32,6 +32,12 @@ module internal Render =
                 | BarcodeFieldDefault bfd ->
                     sb.AppendLine(bfd.ToString()) |> ignore
                     loop tail sb
+                | Comment cm ->
+                    sb.AppendLine(cm.ToString()) |> ignore
+                    loop tail sb
+                | LabelHome lh ->
+                    sb.AppendLine(lh.ToString()) |> ignore
+                    loop tail sb
                 | Collection co ->
                     loop (List.append co tail) sb
 
@@ -178,6 +184,33 @@ type Label =
   static member inline BY w r h =
     { Width = w; Ratio = r; Height = h }
     |> LabelElement.BarcodeFieldDefault
+
+  /// <summary>
+  /// Comment (^FX)
+  ///
+  /// The ^FX command adds a non-printing comment to a label format.
+  /// Any data after ^FX up to the next ^ or ~ command is ignored, so a
+  /// ^FS command should follow it (Fabra appends this automatically).
+  /// </summary>
+  /// <param name="c">Non-printing comment text</param>
+  /// <returns>LabelElement.Comment</returns>
+  static member inline FX c =
+    Comment.Comment c
+    |> LabelElement.Comment
+
+  /// <summary>
+  /// Label Home (^LH)
+  ///
+  /// The ^LH command sets the label home position — the reference point
+  /// for every field that follows it. The default home position is the
+  /// upper-left corner (0,0).
+  /// </summary>
+  /// <param name="x">X-axis position (in dots). Values: 0 to 32000. Default: 0</param>
+  /// <param name="y">Y-axis position (in dots). Values: 0 to 32000. Default: 0</param>
+  /// <returns>LabelElement.LabelHome</returns>
+  static member inline LH x y =
+    { LabelHome.X_Axis = x; Y_Axis = y }
+    |> LabelElement.LabelHome
 
   static member inline Collection lst = LabelElement.Collection lst
 

--- a/Label.fs
+++ b/Label.fs
@@ -189,8 +189,10 @@ type Label =
   /// Comment (^FX)
   ///
   /// The ^FX command adds a non-printing comment to a label format.
-  /// Any data after ^FX up to the next ^ or ~ command is ignored, so a
-  /// ^FS command should follow it (Fabra appends this automatically).
+  /// Any data after ^FX up to the next ^ or ~ command is ignored. The ZPL
+  /// spec terminates ^FX with ^FS, which Fabra appends automatically; place
+  /// a comment between fields rather than between a ^FO and its field
+  /// content, since the trailing ^FS closes the current field.
   /// </summary>
   /// <param name="c">Non-printing comment text</param>
   /// <returns>LabelElement.Comment</returns>

--- a/Types.fs
+++ b/Types.fs
@@ -180,6 +180,19 @@ type BarcodeFieldDefault =
         let ratio = x.Ratio.ToString(CultureInfo.InvariantCulture)
         $"^BY{x.Width},{ratio},{x.Height}"
 
+/// Comment (^FX)
+type Comment =
+    | Comment of string
+    override x.ToString() =
+        let (Comment str) = x
+        $"^FX{str}^FS"
+
+/// Label Home (^LH)
+type LabelHome =
+    { X_Axis: int
+      Y_Axis: int }
+    override x.ToString() = $"^LH{x.X_Axis},{x.Y_Axis}"
+
 /// A label element/command.
 /// Used for containing all label commands within a single collection/label.
 type LabelElement =
@@ -190,4 +203,6 @@ type LabelElement =
     | FieldOrigin of FieldOrigin
     | GraphicBox of GraphicBox
     | BarcodeFieldDefault of BarcodeFieldDefault
+    | Comment of Comment
+    | LabelHome of LabelHome
     | Collection of LabelElement list

--- a/tests/Fabra.Tests/GoldenTests.fs
+++ b/tests/Fabra.Tests/GoldenTests.fs
@@ -53,3 +53,12 @@ module GoldenTests =
     let ``^LH renders the label home position`` () =
         let zpl = ZPL.render (Label [ Label.LH 30 60 ])
         Assert.Contains("^LH30,60", zpl)
+
+    [<Fact>]
+    let ``^FX comment renders as its own statement among fields`` () =
+        let zpl =
+            ZPL.render (Label [
+                Label.FO 60 60 Justification.Left
+                Label.FX "note"
+                Label.Text Orientation.N 30 30 "hi" ])
+        Assert.Equal("^XA\n^FO60,60,0\n^FXnote^FS\n^A0N,30,30^FDhi^FS\n^XZ", normalize zpl)

--- a/tests/Fabra.Tests/GoldenTests.fs
+++ b/tests/Fabra.Tests/GoldenTests.fs
@@ -43,3 +43,13 @@ module GoldenTests =
             Assert.Contains("^BY3,2.5,10", zpl)
         finally
             CultureInfo.CurrentCulture <- original
+
+    [<Fact>]
+    let ``^FX renders a comment terminated by ^FS`` () =
+        let zpl = ZPL.render (Label [ Label.FX "setup notes" ])
+        Assert.Contains("^FXsetup notes^FS", zpl)
+
+    [<Fact>]
+    let ``^LH renders the label home position`` () =
+        let zpl = ZPL.render (Label [ Label.LH 30 60 ])
+        Assert.Contains("^LH30,60", zpl)


### PR DESCRIPTION
## Summary

First batch of the ZPL command roadmap: implements the two simplest missing commands and records the plan for the rest.

- **`^FX` (Comment)** — adds non-printing comments to a label, rendered as `^FX{text}^FS`. New `Comment` type + `Label.FX` factory.
- **`^LH` (Label Home)** — sets the label home reference point that subsequent `^FO` fields are positioned against, rendered as `^LH{x},{y}`. New `LabelHome` type + `Label.LH` factory.
- **`CLAUDE.md`** — new file documenting the project layout, build/test commands, the pattern for adding a command, and a roadmap for the remaining commands (`^A` font selector, `^FB`, `^BQ`, `^GF`).

Both new commands follow the existing pattern: a domain type in `Types.fs`, a `LabelElement` case, a `Label` factory, a `Render.label` branch, and a test.

## Test plan
- [x] `dotnet build Fabra.sln -c Release` — succeeds, 0 warnings
- [x] `dotnet test Fabra.sln` — 6/6 passing (4 existing + 2 new)
- [x] New tests assert `^FX` renders `^FX{text}^FS` and `^LH` renders `^LH{x},{y}`

https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN)_