### PR TITLE
Add ^A font selector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ for simple static labels. Planned additions, ordered easy → hard:
 
 - [x] `^FX` — Comment. New `Comment` type; renders `^FX{text}^FS`.
 - [x] `^LH` — Label Home. New `LabelHome` record (x, y); renders `^LH{x},{y}`.
-- [ ] `^A` font selector — the `Text` type currently hardcodes font `0`
+- [x] `^A` font selector — the `Text` type currently hardcodes font `0`
       (`^A0`). Add a font parameter (`A`–`Z`, `0`–`9`) so other resident
       fonts can be selected. Breaking change to the `Label.Text` factory.
 - [ ] `^FB` — Field Block (word-wrapped, multi-line text). New `FieldBlock`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,13 @@ for simple static labels. Planned additions, ordered easy → hard:
 - [ ] `^GF` — Graphic Field (bitmap images). Largest item; needs an
       image → monochrome-bitmap encoder. Phase 1: accept pre-encoded
       `^GFA` ASCII-hex data. Phase 2: add the image-to-bitmap converter.
+
+## Open design items
+
+- **Input validation.** Fabra performs no validation anywhere — numeric
+  ranges (`^FO`, `^GB`, `^BX`, …) and `^FD`/`^A` content trust the caller,
+  with valid ranges only documented in XML docs. A Copilot review of the
+  `^A` font selector asked whether the `Font` identifier (`A`–`Z`, `0`–`9`)
+  should be validated. Undecided: keep trusting the caller, add validating
+  smart constructors per type, or adopt library-wide validation. If
+  adopted, apply it consistently across all commands rather than ad hoc.

--- a/Examples/AustraliaPost_traditional.fsx
+++ b/Examples/AustraliaPost_traditional.fsx
@@ -16,7 +16,7 @@ open Fabra
 let text x y h w content =
   Label.Collection [
     Label.FO x y Left
-    Label.Text Orientation.N h w content
+    Label.Text (Font '0') Orientation.N h w content
   ]
 
 let line x y w =

--- a/Examples/GS1.fsx
+++ b/Examples/GS1.fsx
@@ -32,7 +32,7 @@ let barcode_SSCC x y content =
 let text x y h w content =
   Label.Collection [
     Label.FO x y Left
-    Label.Text Orientation.N h w content
+    Label.Text (Font '0') Orientation.N h w content
   ]
 
 let line x y w =

--- a/Label.fs
+++ b/Label.fs
@@ -71,13 +71,15 @@ type Label =
   /// The font specified by ^A is used only once for that ^FD entry.
   /// If a value for ^A is not specified again, the default ^CF font is used for the next ^FD entry.
   /// </summary>
+  /// <param name="f">Font identifier (A-Z or 0-9)</param>
   /// <param name="o">Orientation</param>
   /// <param name="h">Character Height (in dots)</param>
   /// <param name="w">Width (in dots)</param>
   /// <param name="fd">Field Data</param>
   /// <returns>LabelElement.Text</returns>
-  static member inline Text o h w (fd: string) =
-    { Orientation = o
+  static member inline Text f o h w (fd: string) =
+    { Font = f
+      Orientation = o
       Height = h
       Width = w
       Data = (FieldData.FieldData fd) }

--- a/Types.fs
+++ b/Types.fs
@@ -83,14 +83,23 @@ type FieldData =
         let (FieldData str) = x
         $"^FD{str}^FS"
 
+/// Resident or downloaded font for the ^A command.
+/// Valid identifiers are A-Z and 0-9.
+type Font =
+    | Font of char
+    override x.ToString() =
+        let (Font c) = x
+        string c
+
 /// Scalable/Bitmapped Font (^A)
 type Text =
-    { Orientation: Orientation
+    { Font: Font
+      Orientation: Orientation
       Height: int
       Width: int
       Data: FieldData }
     override x.ToString() =
-        $"^A0{x.Orientation},{x.Height},{x.Width}{x.Data}"
+        $"^A{x.Font}{x.Orientation},{x.Height},{x.Width}{x.Data}"
 
 /// Code 128 Bar Code, Subsets A, B, and C (^BC)
 type Barcode =

--- a/tests/Fabra.Tests/Examples.fs
+++ b/tests/Fabra.Tests/Examples.fs
@@ -27,7 +27,7 @@ module Examples =
         let private text x y h w content =
             Label.Collection [
                 Label.FO x y Left
-                Label.Text Orientation.N h w content
+                Label.Text (Font '0') Orientation.N h w content
             ]
 
         let private line x y w =
@@ -76,7 +76,7 @@ module Examples =
         let private text x y h w content =
             Label.Collection [
                 Label.FO x y Left
-                Label.Text Orientation.N h w content
+                Label.Text (Font '0') Orientation.N h w content
             ]
 
         let private line x y w =

--- a/tests/Fabra.Tests/GoldenTests.fs
+++ b/tests/Fabra.Tests/GoldenTests.fs
@@ -60,5 +60,10 @@ module GoldenTests =
             ZPL.render (Label [
                 Label.FO 60 60 Justification.Left
                 Label.FX "note"
-                Label.Text Orientation.N 30 30 "hi" ])
+                Label.Text (Font '0') Orientation.N 30 30 "hi" ])
         Assert.Equal("^XA\n^FO60,60,0\n^FXnote^FS\n^A0N,30,30^FDhi^FS\n^XZ", normalize zpl)
+
+    [<Fact>]
+    let ``^A renders the selected font`` () =
+        let zpl = ZPL.render (Label [ Label.Text (Font 'A') Orientation.N 30 20 "hi" ])
+        Assert.Contains("^AAN,30,20^FDhi^FS", zpl)


### PR DESCRIPTION
## Summary

Next roadmap item: the `^A` font selector.

The `Text` type hardcoded font `0` (it always emitted `^A0`). This adds a `Font` type — a `char` identifier (`A`–`Z` or `0`–`9`) — threaded through the `Text` record and renderer, which now emits `^A{font}{orientation},{h},{w}`.

**Breaking change:** `Label.Text` now takes the font as its first argument: `Label.Text (Font '0') Orientation.N h w "text"`. The examples and tests are updated to pass `Font '0'`, so their generated ZPL is unchanged.

## Test plan
- [x] `dotnet build Fabra.sln -c Release` — succeeds, 0 warnings
- [x] `dotnet test Fabra.sln` — 8/8 passing (golden tests confirm `Font '0'` still renders `^A0...`)
- [x] New test asserts `Label.Text (Font 'A') ...` renders `^AAN,...`

https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN)_