### PR TITLE
Add ^FB (Field Block) command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ for simple static labels. Planned additions, ordered easy → hard:
 - [x] `^A` font selector — the `Text` type currently hardcodes font `0`
       (`^A0`). Add a font parameter (`A`–`Z`, `0`–`9`) so other resident
       fonts can be selected. Breaking change to the `Label.Text` factory.
-- [ ] `^FB` — Field Block (word-wrapped, multi-line text). New `FieldBlock`
+- [x] `^FB` — Field Block (word-wrapped, multi-line text). New `FieldBlock`
       type (width, max lines, line spacing, justification, hanging indent);
       a modifier emitted before the `^FD` it applies to.
 - [ ] `^BQ` — QR Code. New `QrCode` type (orientation, model,

--- a/Label.fs
+++ b/Label.fs
@@ -17,6 +17,9 @@ module internal Render =
                 | Text txt ->
                     sb.AppendLine(txt.ToString()) |> ignore
                     loop tail sb
+                | FieldBlock fb ->
+                    sb.AppendLine(fb.ToString()) |> ignore
+                    loop tail sb
                 | Barcode bc ->
                     sb.AppendLine(bc.ToString()) |> ignore
                     loop tail sb
@@ -85,7 +88,30 @@ type Label =
       Data = (FieldData.FieldData fd) }
     |> LabelElement.Text
 
-    
+  /// <summary>
+  /// Field Block (^FB)
+  ///
+  /// The ^FB command prints text into a defined block-type format,
+  /// word-wrapping a single ^FD field across multiple lines within a
+  /// fixed-width block. It is a modifier emitted immediately before the
+  /// ^FD it applies to.
+  /// </summary>
+  /// <param name="w">Width of the text block line (in dots). Values: 0 to the label width. Default: 0</param>
+  /// <param name="l">Maximum number of lines in the text block. Values: 1 to 9999. Default: 1</param>
+  /// <param name="s">Space added or deleted between lines (in dots). Values: -9999 to 9999. Default: 0</param>
+  /// <param name="j">Text justification. Values: L = left, C = centre, R = right, J = justified. Default: L</param>
+  /// <param name="i">Hanging indent (in dots) of the second and remaining lines. Values: 0 to 9999. Default: 0</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.FieldBlock</returns>
+  static member inline FB w l s j i (fd: string) =
+    { FieldBlock.Width = w
+      MaxLines = l
+      LineSpacing = s
+      Justification = j
+      HangingIndent = i
+      Data = (FieldData.FieldData fd) }
+    |> LabelElement.FieldBlock
+
   /// <summary>
   /// Code 128 Bar Code, Subsets A, B, and C (^BC)
   ///

--- a/Types.fs
+++ b/Types.fs
@@ -64,6 +64,24 @@ type Justification =
       | Right -> "1"
       | Justified -> "2"
 
+/// Text justification for the Field Block (^FB) command.
+[<RequireQualifiedAccess>]
+type FieldBlockJustification =
+  /// Left
+  | Left
+  /// Centre
+  | Centre
+  /// Right
+  | Right
+  /// Justified
+  | Justified
+  override x.ToString() =
+      match x with
+      | FieldBlockJustification.Left -> "L"
+      | FieldBlockJustification.Centre -> "C"
+      | FieldBlockJustification.Right -> "R"
+      | FieldBlockJustification.Justified -> "J"
+
 /// Line Colour
 [<RequireQualifiedAccess>]
 type LineColour =
@@ -100,6 +118,18 @@ type Text =
       Data: FieldData }
     override x.ToString() =
         $"^A{x.Font}{x.Orientation},{x.Height},{x.Width}{x.Data}"
+
+/// Field Block (^FB)
+/// A modifier emitted immediately before the ^FD it word-wraps.
+type FieldBlock =
+    { Width: int
+      MaxLines: int
+      LineSpacing: int
+      Justification: FieldBlockJustification
+      HangingIndent: int
+      Data: FieldData }
+    override x.ToString() =
+        $"^FB{x.Width},{x.MaxLines},{x.LineSpacing},{x.Justification},{x.HangingIndent}{x.Data}"
 
 /// Code 128 Bar Code, Subsets A, B, and C (^BC)
 type Barcode =
@@ -207,6 +237,7 @@ type LabelHome =
 type LabelElement =
     | FieldData of FieldData
     | Text of Text
+    | FieldBlock of FieldBlock
     | Barcode of Barcode
     | DataMatrixBarcode of DataMatrixBarcode
     | FieldOrigin of FieldOrigin

--- a/tests/Fabra.Tests/GoldenTests.fs
+++ b/tests/Fabra.Tests/GoldenTests.fs
@@ -67,3 +67,13 @@ module GoldenTests =
     let ``^A renders the selected font`` () =
         let zpl = ZPL.render (Label [ Label.Text (Font 'A') Orientation.N 30 20 "hi" ])
         Assert.Contains("^AAN,30,20^FDhi^FS", zpl)
+
+    [<Fact>]
+    let ``^FB renders a field block before its field data`` () =
+        let zpl = ZPL.render (Label [ Label.FB 400 3 0 FieldBlockJustification.Left 0 "wrapped text" ])
+        Assert.Contains("^FB400,3,0,L,0^FDwrapped text^FS", zpl)
+
+    [<Fact>]
+    let ``^FB justification renders the ZPL letter`` () =
+        let zpl = ZPL.render (Label [ Label.FB 200 2 5 FieldBlockJustification.Centre 10 "x" ])
+        Assert.Contains("^FB200,2,5,C,10^FDx^FS", zpl)


### PR DESCRIPTION
## Summary

Implements `^FB` (Field Block), the next item on the ZPL roadmap — word-wrapped, multi-line text within a fixed-width block.

- `Types.fs`: new `FieldBlock` record (width, max lines, line spacing, justification, hanging indent, data) rendering `^FB{w},{l},{s},{j},{i}` immediately followed by its `^FD…^FS`, plus a `FieldBlockJustification` union (`Left`/`Centre`/`Right`/`Justified` → `L`/`C`/`R`/`J`). New `FieldBlock` case on `LabelElement`.
- `Label.fs`: `Label.FB w l s j i fd` factory and the matching `Render.label` branch.
- `tests/Fabra.Tests/GoldenTests.fs`: two rendering tests (basic block + justification letter).
- `CLAUDE.md`: ticked `^FB` off the roadmap.

`^FB` is emitted as a modifier directly before the `^FD` it wraps, consistent with the ZPL spec. Justification uses the `^FB` letter set (`L/C/R/J`), distinct from the existing `Justification` type used by `^FO` (`0/1/2`).

No validation is performed on the numeric parameters, consistent with the rest of the library (tracked as the input-validation open design item in `CLAUDE.md`).

## Test plan

- [x] `dotnet build Fabra.sln -c Release` — clean, 0 warnings
- [x] `dotnet test Fabra.sln` — 10/10 passing
- [x] Existing golden files unchanged (`^FB` not used in the example labels)

https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN)_