### PR TITLE
Add ^BQ (QR Code) command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,16 @@ for simple static labels. Planned additions, ordered easy → hard:
   should be validated. Undecided: keep trusting the caller, add validating
   smart constructors per type, or adopt library-wide validation. If
   adopted, apply it consistently across all commands rather than ad hoc.
+
+- **Feliz-style props API.** Commands currently take positional arguments
+  via `static member` factories (e.g.
+  `Label.BC Orientation.N 378 YesNo.N YesNo.N YesNo.N Mode.A data`), which
+  reads poorly for commands with many parameters or defaults. An
+  alternative is a Feliz-style list of props — e.g.
+  `Label.qr [ qr.model 2; qr.magnification 10; qr.data "…" ]` — built from
+  a per-command prop DU folded onto a defaulted record (no need for
+  Feliz's erased-type machinery). Trades the compile-time "all required
+  fields set" guarantee for default-backed optional props, and would be a
+  library-wide change applied consistently rather than per command (ties
+  into the validation item above). Worth a throwaway spike on one command
+  before committing. Keep the current positional style until then.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ for simple static labels. Planned additions, ordered easy → hard:
 - [x] `^FB` — Field Block (word-wrapped, multi-line text). New `FieldBlock`
       type (width, max lines, line spacing, justification, hanging indent);
       a modifier emitted before the `^FD` it applies to.
-- [ ] `^BQ` — QR Code. New `QrCode` type (orientation, model,
+- [x] `^BQ` — QR Code. New `QrCode` type (orientation, model,
       magnification, error correction, mask); renders `^BQ...` plus `^FD`.
 - [ ] `^GF` — Graphic Field (bitmap images). Largest item; needs an
       image → monochrome-bitmap encoder. Phase 1: accept pre-encoded

--- a/Label.fs
+++ b/Label.fs
@@ -26,6 +26,9 @@ module internal Render =
                 | DataMatrixBarcode bc ->
                     sb.AppendLine(bc.ToString()) |> ignore
                     loop tail sb
+                | QrCode qr ->
+                    sb.AppendLine(qr.ToString()) |> ignore
+                    loop tail sb
                 | FieldOrigin fo ->
                     sb.AppendLine(fo.ToString()) |> ignore
                     loop tail sb
@@ -169,6 +172,31 @@ type Label =
       AspectRatio = a
       Data = (FieldData.FieldData fd) }
     |> LabelElement.DataMatrixBarcode
+
+  /// <summary>
+  /// QR Code Bar Code (^BQ)
+  ///
+  /// The ^BQ command produces a QR Code, a two-dimensional matrix
+  /// symbology. Fabra always uses automatic data input mode; the
+  /// error-correction level is emitted both in the ^BQ command and in the
+  /// ^FD prefix (as ^FD{e}A,{data}^FS), which the QR field-data format
+  /// requires.
+  /// </summary>
+  /// <param name="o">Field orientation</param>
+  /// <param name="m">Model. Values: 1 = original, 2 = enhanced (recommended). Default: 2</param>
+  /// <param name="f">Magnification factor. Values: 1 to 10</param>
+  /// <param name="e">Error correction level. Values: H (~30%), Q (~25%), M (~15%), L (~7%)</param>
+  /// <param name="k">Mask value. Values: 0 to 7. Default: 7</param>
+  /// <param name="fd">Field Data to encode</param>
+  /// <returns>LabelElement.QrCode</returns>
+  static member inline BQ o m f e k (fd: string) =
+    { QrCode.Orientation = o
+      Model = m
+      Magnification = f
+      ErrorCorrection = e
+      Mask = k
+      Data = fd }
+    |> LabelElement.QrCode
 
   /// <summary>
   /// Field Origin (^FO)

--- a/Types.fs
+++ b/Types.fs
@@ -187,6 +187,38 @@ type DataMatrixBarcode =
           | None -> s1 + ","
         $"^BX{x.Orientation},{x.DimensionalHeight},{x.QualityLevel}" +. x.ColumnsToEncode  +. x.RowsToEncode +. x.FormatId +. x.EscapeSequenceControlCharacter +. x.AspectRatio + $"{x.Data}"
 
+/// QR Code error correction level for the ^BQ command.
+[<RequireQualifiedAccess>]
+type QrErrorCorrection =
+  /// Ultra-high reliability (~30% recovery)
+  | H
+  /// High reliability (~25% recovery)
+  | Q
+  /// Standard (~15% recovery)
+  | M
+  /// High density (~7% recovery)
+  | L
+  override x.ToString() =
+    match x with
+    | QrErrorCorrection.H -> "H"
+    | QrErrorCorrection.Q -> "Q"
+    | QrErrorCorrection.M -> "M"
+    | QrErrorCorrection.L -> "L"
+
+/// QR Code Bar Code (^BQ)
+/// The error-correction level is repeated in the ^FD prefix and Fabra
+/// always uses automatic input mode (A), so the field data is emitted as
+/// ^FD{errorCorrection}A,{data}^FS.
+type QrCode =
+    { Orientation: Orientation
+      Model: int
+      Magnification: int
+      ErrorCorrection: QrErrorCorrection
+      Mask: int
+      Data: string }
+    override x.ToString() =
+        $"^BQ{x.Orientation},{x.Model},{x.Magnification},{x.ErrorCorrection},{x.Mask}^FD{x.ErrorCorrection}A,{x.Data}^FS"
+
 /// Field Origin (^FO)
 type FieldOrigin =
     { X_Axis: int
@@ -240,6 +272,7 @@ type LabelElement =
     | FieldBlock of FieldBlock
     | Barcode of Barcode
     | DataMatrixBarcode of DataMatrixBarcode
+    | QrCode of QrCode
     | FieldOrigin of FieldOrigin
     | GraphicBox of GraphicBox
     | BarcodeFieldDefault of BarcodeFieldDefault

--- a/tests/Fabra.Tests/GoldenTests.fs
+++ b/tests/Fabra.Tests/GoldenTests.fs
@@ -77,3 +77,13 @@ module GoldenTests =
     let ``^FB justification renders the ZPL letter`` () =
         let zpl = ZPL.render (Label [ Label.FB 200 2 5 FieldBlockJustification.Centre 10 "x" ])
         Assert.Contains("^FB200,2,5,C,10^FDx^FS", zpl)
+
+    [<Fact>]
+    let ``^BQ renders the QR command with a prefixed field data`` () =
+        let zpl = ZPL.render (Label [ Label.BQ Orientation.N 2 10 QrErrorCorrection.Q 7 "HELLO" ])
+        Assert.Contains("^BQN,2,10,Q,7^FDQA,HELLO^FS", zpl)
+
+    [<Fact>]
+    let ``^BQ repeats the error-correction level in the ^FD prefix`` () =
+        let zpl = ZPL.render (Label [ Label.BQ Orientation.N 2 4 QrErrorCorrection.H 5 "data" ])
+        Assert.Contains("^BQN,2,4,H,5^FDHA,data^FS", zpl)


### PR DESCRIPTION
## Summary

Implements `^BQ` (QR Code), the next item on the ZPL roadmap, in the existing positional style.

- `Types.fs`: new `QrCode` record (orientation, model, magnification, error correction, mask, data) plus a `QrErrorCorrection` union (`H`/`Q`/`M`/`L`). New `QrCode` case on `LabelElement`.
- `Label.fs`: `Label.BQ o m f e k fd` factory and the matching `Render.label` branch.
- `tests/Fabra.Tests/GoldenTests.fs`: two rendering tests.
- `CLAUDE.md`: ticked `^BQ` off the roadmap; also carries the previously-logged **Feliz-style props API** open design item (committed earlier on this branch).

## Design note — the QR `^FD` is special

Unlike `^A`/`^BC`, a QR code's `^FD` is **not** verbatim text: the field-data format requires the error-correction level and an input-mode letter prefixed before the data. So `QrCode` owns its `^FD` rather than reusing the shared `FieldData` type, and Fabra always uses **automatic input mode** (`A`).

Rendering (validated against the shipping [`sharpzebra`](https://github.com/rkone/sharpzebra) library and the roadmap's field list):

```fsharp
Label.BQ Orientation.N 2 10 QrErrorCorrection.Q 7 "HELLO"
```
renders
```
^BQN,2,10,Q,7^FDQA,HELLO^FS
```

`^BQ` carries orientation, model, magnification, error-correction and mask; the `^FD` repeats the error-correction level plus `A` (automatic). Per Fabra convention there's no input validation on the numeric params (tracked as the input-validation open design item).

I had to reconcile conflicting docs on whether error-correction/mask live on `^BQ` or in `^FD` — happy to adjust the encoding if your target printers expect a different form.

## Test plan

- [x] `dotnet build Fabra.sln -c Release` — clean, 0 warnings
- [x] `dotnet test Fabra.sln` — 12/12 passing
- [x] Existing golden files unchanged (`^BQ` not used in the example labels)

https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN)_