### PR TITLE
Add ^GF (Graphic Field) phase 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,10 @@ for simple static labels. Planned additions, ordered easy → hard:
 - [x] `^BQ` — QR Code. New `QrCode` type (orientation, model,
       magnification, error correction, mask); renders `^BQ...` plus `^FD`.
 - [ ] `^GF` — Graphic Field (bitmap images). Largest item; needs an
-      image → monochrome-bitmap encoder. Phase 1: accept pre-encoded
-      `^GFA` ASCII-hex data. Phase 2: add the image-to-bitmap converter.
+      image → monochrome-bitmap encoder.
+  - [x] Phase 1: accept pre-encoded `^GFA` ASCII-hex data (`GraphicField`
+        type; renders `^GFA,{b},{c},{d},{data}^FS`).
+  - [ ] Phase 2: add the image-to-bitmap converter.
 
 ## Open design items
 

--- a/Label.fs
+++ b/Label.fs
@@ -35,6 +35,9 @@ module internal Render =
                 | GraphicBox gb ->
                     sb.AppendLine(gb.ToString()) |> ignore
                     loop tail sb
+                | GraphicField gf ->
+                    sb.AppendLine(gf.ToString()) |> ignore
+                    loop tail sb
                 | BarcodeFieldDefault bfd ->
                     sb.AppendLine(bfd.ToString()) |> ignore
                     loop tail sb
@@ -232,6 +235,26 @@ type Label =
       LineColour = c
       Rounding = r }
     |> LabelElement.GraphicBox
+
+  /// <summary>
+  /// Graphic Field (^GF)
+  ///
+  /// The ^GF command lets you download a graphic image and print it as part
+  /// of a label. Phase 1 accepts pre-encoded ASCII-hex (^GFA) data: the
+  /// caller supplies the byte counts and the hex string, which is emitted
+  /// verbatim. (An image-to-bitmap encoder is a future addition.)
+  /// </summary>
+  /// <param name="b">Binary byte count — total bytes to be transmitted; for ASCII-hex data this equals the graphic field count. Values: 1 to 99999</param>
+  /// <param name="c">Graphic field count — total bytes comprising the image (bytes per row × number of rows). Values: 1 to 99999</param>
+  /// <param name="d">Bytes per row — number of bytes in one row of the image. Values: 1 to 99999</param>
+  /// <param name="data">Pre-encoded ASCII-hex graphic data</param>
+  /// <returns>LabelElement.GraphicField</returns>
+  static member inline GF b c d (data: string) =
+    { GraphicField.BinaryByteCount = b
+      GraphicFieldCount = c
+      BytesPerRow = d
+      Data = data }
+    |> LabelElement.GraphicField
 
   /// Bar Code Field Default (^BY)
   ///

--- a/Types.fs
+++ b/Types.fs
@@ -236,6 +236,17 @@ type GraphicBox =
     override x.ToString() =
         $"^GB{x.Width},{x.Height},{x.Thickness},{x.LineColour},{x.Rounding}^FS"
 
+/// Graphic Field (^GF)
+/// Phase 1: pre-encoded ASCII-hex (^GFA) bitmap data supplied by the
+/// caller. The data string is emitted verbatim.
+type GraphicField =
+    { BinaryByteCount: int
+      GraphicFieldCount: int
+      BytesPerRow: int
+      Data: string }
+    override x.ToString() =
+        $"^GFA,{x.BinaryByteCount},{x.GraphicFieldCount},{x.BytesPerRow},{x.Data}^FS"
+
 /// Bar Code Field Default (^BY)
 type BarcodeFieldDefault =
     {
@@ -275,6 +286,7 @@ type LabelElement =
     | QrCode of QrCode
     | FieldOrigin of FieldOrigin
     | GraphicBox of GraphicBox
+    | GraphicField of GraphicField
     | BarcodeFieldDefault of BarcodeFieldDefault
     | Comment of Comment
     | LabelHome of LabelHome

--- a/tests/Fabra.Tests/GoldenTests.fs
+++ b/tests/Fabra.Tests/GoldenTests.fs
@@ -87,3 +87,8 @@ module GoldenTests =
     let ``^BQ repeats the error-correction level in the ^FD prefix`` () =
         let zpl = ZPL.render (Label [ Label.BQ Orientation.N 2 4 QrErrorCorrection.H 5 "data" ])
         Assert.Contains("^BQN,2,4,H,5^FDHA,data^FS", zpl)
+
+    [<Fact>]
+    let ``^GF renders pre-encoded ASCII-hex graphic data`` () =
+        let zpl = ZPL.render (Label [ Label.GF 8 8 2 "FF00FF00FF00FF00" ])
+        Assert.Contains("^GFA,8,8,2,FF00FF00FF00FF00^FS", zpl)


### PR DESCRIPTION
## Summary

Implements **Phase 1** of `^GF` (Graphic Field) — the last roadmap item — in the existing positional style. Phase 1 accepts pre-encoded ASCII-hex (`^GFA`) bitmap data; the image-to-bitmap encoder (Phase 2) is intentionally left for later.

- `Types.fs`: new `GraphicField` record (binary byte count, graphic field count, bytes per row, data) rendering `^GFA,{b},{c},{d},{data}^FS`. New `GraphicField` case on `LabelElement`.
- `Label.fs`: `Label.GF b c d data` factory and the matching `Render.label` branch.
- `tests/Fabra.Tests/GoldenTests.fs`: one rendering test.
- `CLAUDE.md`: ticked Phase 1 off the `^GF` roadmap item; Phase 2 remains open.

## Behaviour

```fsharp
Label.GF 8 8 2 "FF00FF00FF00FF00"
```
renders
```
^GFA,8,8,2,FF00FF00FF00FF00^FS
```

The compression type is fixed to `A` (ASCII hex) for Phase 1, matching the roadmap scope. The hex data is emitted verbatim — the caller supplies both the byte counts and the encoded payload. Per Fabra convention there's no validation on the counts or hex content (tracked as the input-validation open design item).

## Test plan

- [x] `dotnet build Fabra.sln -c Release` — clean, 0 warnings
- [x] `dotnet test Fabra.sln` — 13/13 passing
- [x] Existing golden files unchanged (`^GF` not used in the example labels)

https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN)_