### PR TITLE
Add ^GF phase 2: image-to-bitmap converter (Fabra.Imaging)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,9 @@ An F# DSL for generating Zebra Programming Language (ZPL) labels.
 - `Types.fs` — ZPL command domain types; each renders itself via `ToString()`.
 - `Label.fs` — the `Label` type with `static member` factory functions, the
   internal `Render` module, and the public `ZPL.render` function.
+- `Fabra.Imaging/` — optional companion package (`net8.0`) that converts
+  image files to `^GF` graphic fields via SixLabors.ImageSharp. Keeps the
+  image dependency out of the zero-dependency core.
 - `Examples/` — `.fsx` scripts plus their expected `.zpl` golden output.
 - `tests/Fabra.Tests/` — xUnit golden-file and rendering tests.
 
@@ -54,11 +57,13 @@ for simple static labels. Planned additions, ordered easy → hard:
       a modifier emitted before the `^FD` it applies to.
 - [x] `^BQ` — QR Code. New `QrCode` type (orientation, model,
       magnification, error correction, mask); renders `^BQ...` plus `^FD`.
-- [ ] `^GF` — Graphic Field (bitmap images). Largest item; needs an
+- [x] `^GF` — Graphic Field (bitmap images). Largest item; needed an
       image → monochrome-bitmap encoder.
   - [x] Phase 1: accept pre-encoded `^GFA` ASCII-hex data (`GraphicField`
         type; renders `^GFA,{b},{c},{d},{data}^FS`).
-  - [ ] Phase 2: add the image-to-bitmap converter.
+  - [x] Phase 2: image-to-bitmap converter in the `Fabra.Imaging` package
+        (`ImageField.fromFile`/`fromStream`); luminance threshold (default)
+        or Floyd–Steinberg dithering.
 
 ## Open design items
 

--- a/Fabra.Imaging/Fabra.Imaging.fsproj
+++ b/Fabra.Imaging/Fabra.Imaging.fsproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="ImageField.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Fabra.fsproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <PackageId>Fabra.Imaging</PackageId>
+    <Version>0.0.1</Version>
+    <Title>Fabra.Imaging</Title>
+    <Authors>Rob Slavin</Authors>
+    <Company>Rob Slavin</Company>
+    <Description>Image-to-ZPL (^GF) conversion for Fabra, powered by SixLabors.ImageSharp.</Description>
+    <PackageTags>fsharp;ZPL;zebra;label;image;graphic</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageProjectUrl>https://github.com/auslavs/Fabra</PackageProjectUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/auslavs/Fabra</RepositoryUrl>
+  </PropertyGroup>
+
+</Project>

--- a/Fabra.Imaging/Fabra.Imaging.fsproj
+++ b/Fabra.Imaging/Fabra.Imaging.fsproj
@@ -23,7 +23,7 @@
     <Title>Fabra.Imaging</Title>
     <Authors>Rob Slavin</Authors>
     <Company>Rob Slavin</Company>
-    <Description>Image-to-ZPL (^GF) conversion for Fabra, powered by SixLabors.ImageSharp.</Description>
+    <Description>Image-to-ZPL (^GF) conversion for Fabra, powered by SixLabors.ImageSharp. Note: Fabra.Imaging's own code is MIT-licensed, but it depends on SixLabors.ImageSharp 3.x, which is distributed under the Six Labors Split License (free for open-source and personal use; some commercial use requires a paid licence).</Description>
     <PackageTags>fsharp;ZPL;zebra;label;image;graphic</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/Fabra.Imaging/ImageField.fs
+++ b/Fabra.Imaging/ImageField.fs
@@ -1,0 +1,84 @@
+namespace Fabra.Imaging
+
+open System.IO
+open System.Text
+open SixLabors.ImageSharp
+open SixLabors.ImageSharp.PixelFormats
+open Fabra
+
+/// Algorithm for reducing an image to ZPL's 1-bit (black/white) monochrome.
+[<RequireQualifiedAccess>]
+type Dithering =
+    /// Per-pixel luminance threshold — no dithering. Ideal for logos and line art.
+    | Threshold
+    /// Floyd–Steinberg error-diffusion dithering. Better for photos and gradients.
+    | FloydSteinberg
+
+/// Converts images to ZPL Graphic Field (^GF) elements via SixLabors.ImageSharp.
+module ImageField =
+
+    /// Default luminance cutoff (0-255): pixels darker than this print as black dots.
+    [<Literal>]
+    let DefaultThreshold = 128
+
+    /// Pack a width×height monochrome predicate into ^GFA bytes (8 pixels per
+    /// byte, most-significant bit leftmost, each row padded to a whole byte).
+    let private pack (width: int) (height: int) (isBlack: int -> int -> bool) : GraphicField =
+        let bytesPerRow = (width + 7) / 8
+        let sb = StringBuilder(bytesPerRow * height * 2)
+        for y in 0 .. height - 1 do
+            for byteIndex in 0 .. bytesPerRow - 1 do
+                let mutable b = 0
+                for bit in 0 .. 7 do
+                    let x = byteIndex * 8 + bit
+                    if x < width && isBlack x y then
+                        b <- b ||| (0x80 >>> bit)
+                sb.Append(b.ToString("X2")) |> ignore
+        let total = bytesPerRow * height
+        { GraphicField.BinaryByteCount = total
+          GraphicFieldCount = total
+          BytesPerRow = bytesPerRow
+          Data = sb.ToString() }
+
+    let private encode (dithering: Dithering) (threshold: int) (image: Image<L8>) : GraphicField =
+        let width = image.Width
+        let height = image.Height
+        match dithering with
+        | Dithering.Threshold ->
+            pack width height (fun x y -> int image.[x, y].PackedValue < threshold)
+        | Dithering.FloydSteinberg ->
+            let buf = Array2D.init height width (fun y x -> float image.[x, y].PackedValue)
+            let black = Array2D.zeroCreate<bool> height width
+            for y in 0 .. height - 1 do
+                for x in 0 .. width - 1 do
+                    let oldValue = buf.[y, x]
+                    let newValue = if oldValue < float threshold then 0.0 else 255.0
+                    black.[y, x] <- newValue = 0.0
+                    let err = oldValue - newValue
+                    if x + 1 < width then
+                        buf.[y, x + 1] <- buf.[y, x + 1] + err * 7.0 / 16.0
+                    if y + 1 < height then
+                        if x > 0 then buf.[y + 1, x - 1] <- buf.[y + 1, x - 1] + err * 3.0 / 16.0
+                        buf.[y + 1, x] <- buf.[y + 1, x] + err * 5.0 / 16.0
+                        if x + 1 < width then buf.[y + 1, x + 1] <- buf.[y + 1, x + 1] + err * 1.0 / 16.0
+            pack width height (fun x y -> black.[y, x])
+
+    /// Convert an image stream to a ^GF graphic field using the given dithering
+    /// algorithm and luminance cutoff (0-255).
+    let fromStreamWith (dithering: Dithering) (threshold: int) (stream: Stream) : LabelElement =
+        use image = Image.Load<L8>(stream)
+        encode dithering threshold image |> LabelElement.GraphicField
+
+    /// Convert an image stream using a luminance threshold of 128 (no dithering).
+    let fromStream (stream: Stream) : LabelElement =
+        fromStreamWith Dithering.Threshold DefaultThreshold stream
+
+    /// Convert an image file to a ^GF graphic field using the given dithering
+    /// algorithm and luminance cutoff (0-255).
+    let fromFileWith (dithering: Dithering) (threshold: int) (path: string) : LabelElement =
+        use stream = File.OpenRead(path)
+        fromStreamWith dithering threshold stream
+
+    /// Convert an image file using a luminance threshold of 128 (no dithering).
+    let fromFile (path: string) : LabelElement =
+        fromFileWith Dithering.Threshold DefaultThreshold path

--- a/Fabra.sln
+++ b/Fabra.sln
@@ -9,6 +9,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{C10FE288
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fabra.Tests", "tests\Fabra.Tests\Fabra.Tests.fsproj", "{CA1C50CD-3D39-4AE6-8D8E-4C52319BF0D1}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fabra.Imaging", "Fabra.Imaging\Fabra.Imaging.fsproj", "{D1EA891D-75F1-4621-A166-BC6BB445DE1A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{CA1C50CD-3D39-4AE6-8D8E-4C52319BF0D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CA1C50CD-3D39-4AE6-8D8E-4C52319BF0D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CA1C50CD-3D39-4AE6-8D8E-4C52319BF0D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D1EA891D-75F1-4621-A166-BC6BB445DE1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1EA891D-75F1-4621-A166-BC6BB445DE1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1EA891D-75F1-4621-A166-BC6BB445DE1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1EA891D-75F1-4621-A166-BC6BB445DE1A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{CA1C50CD-3D39-4AE6-8D8E-4C52319BF0D1} = {C10FE288-D130-43BA-885A-A77E594DDEAD}

--- a/tests/Fabra.Tests/Fabra.Tests.fsproj
+++ b/tests/Fabra.Tests/Fabra.Tests.fsproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="Examples.fs" />
     <Compile Include="GoldenTests.fs" />
+    <Compile Include="ImageTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
@@ -34,6 +35,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Fabra.fsproj" />
+    <ProjectReference Include="..\..\Fabra.Imaging\Fabra.Imaging.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Fabra.Tests/ImageTests.fs
+++ b/tests/Fabra.Tests/ImageTests.fs
@@ -1,0 +1,51 @@
+namespace Fabra.Tests
+
+open System.IO
+open Xunit
+open SixLabors.ImageSharp
+open SixLabors.ImageSharp.PixelFormats
+open Fabra
+open Fabra.Imaging
+
+/// Tests for the Fabra.Imaging image → ^GF converter. Images are built in
+/// memory and round-tripped through PNG (lossless) so the expected bytes are
+/// deterministic.
+module ImageTests =
+
+    let private black = Rgba32(0uy, 0uy, 0uy, 255uy)
+    let private white = Rgba32(255uy, 255uy, 255uy, 255uy)
+
+    let private pngStream (width: int) (height: int) (paint: Image<Rgba32> -> unit) : MemoryStream =
+        use image = new Image<Rgba32>(width, height)
+        paint image
+        let ms = new MemoryStream()
+        image.SaveAsPng(ms)
+        ms.Position <- 0L
+        ms
+
+    [<Fact>]
+    let ``threshold packs an 8x1 black/white row to F0`` () =
+        use ms =
+            pngStream 8 1 (fun image ->
+                for x in 0 .. 3 do image.[x, 0] <- black
+                for x in 4 .. 7 do image.[x, 0] <- white)
+        let zpl = ZPL.render (Label [ ImageField.fromStream ms ])
+        Assert.Contains("^GFA,1,1,1,F0^FS", zpl)
+
+    [<Fact>]
+    let ``rows are padded to a whole byte`` () =
+        // 9 black pixels: row spans two bytes -> FF then 1000_0000 (0x80).
+        use ms =
+            pngStream 9 1 (fun image ->
+                for x in 0 .. 8 do image.[x, 0] <- black)
+        let zpl = ZPL.render (Label [ ImageField.fromStream ms ])
+        Assert.Contains("^GFA,2,2,2,FF80^FS", zpl)
+
+    [<Fact>]
+    let ``a fully white image produces all-zero bytes`` () =
+        use ms =
+            pngStream 8 2 (fun image ->
+                for y in 0 .. 1 do
+                    for x in 0 .. 7 do image.[x, y] <- white)
+        let zpl = ZPL.render (Label [ ImageField.fromStream ms ])
+        Assert.Contains("^GFA,2,2,1,0000^FS", zpl)


### PR DESCRIPTION
## Summary

Implements **Phase 2** of `^GF` — the image-to-bitmap converter — completing the ZPL command roadmap. Per the design decision, the image dependency lives in a **separate `Fabra.Imaging` package** so the core stays zero-dependency.

- **New `Fabra.Imaging` project** (`net8.0`) referencing core Fabra + `SixLabors.ImageSharp`.
  - `ImageField.fromFile` / `fromStream` — convert an image with a luminance threshold of 128 (no dithering).
  - `ImageField.fromFileWith` / `fromStreamWith dithering threshold` — full control.
  - `Dithering` union: `Threshold` (default) or `FloydSteinberg`.
  - Pipeline: decode → `L8` luminance → threshold or Floyd–Steinberg → pack 8 px/byte (MSB leftmost, rows padded to a whole byte) → ASCII-hex → a Phase 1 `GraphicField` (`LabelElement`).
- **Tests**: `tests/Fabra.Tests/ImageTests.fs` builds images in memory, round-trips them through lossless PNG, and asserts exact `^GFA` bytes (incl. row padding and an all-white case).
- **CLAUDE.md**: project layout + roadmap updated; `^GF` (and Phase 2) ticked off.

## Usage

```fsharp
open Fabra
open Fabra.Imaging

Label [
  Label.FO 50 50 Left
  ImageField.fromFile "logo.png"                              // threshold 128
  ImageField.fromFileWith Dithering.FloydSteinberg 100 "photo.png"
]
```

## Notes for review

- **Separate package / TFM**: `Fabra.Imaging` targets `net8.0` (core remains `netstandard2.0`). I moved off ImageSharp 2.x because every 2.x release carries known high/moderate advisories; **`SixLabors.ImageSharp 3.1.11`** restores with no vulnerability warnings but requires `net6.0+`, hence the `net8.0` target for this optional package.
- **Licence**: ImageSharp 3.x uses the Six Labors Split License (free for OSS, commercial use needs a licence). Isolating it in an optional package means core Fabra (MIT) consumers are unaffected unless they opt into `Fabra.Imaging`.
- No input validation, per the existing convention (tracked as an open design item).

## Test plan

- [x] `dotnet build Fabra.sln -c Release` — clean, 0 warnings
- [x] `dotnet test Fabra.sln` — 16/16 passing (3 new image tests)
- [x] Existing golden files unchanged

https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN)_