### PR TITLE
Add 15 common ZPL commands and catalogue the full command set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,9 @@ Each command follows the same pattern:
 
 ## ZPL command roadmap
 
-Fabra implements roughly 10 of the ~200 ZPL commands — the subset needed
-for simple static labels. Planned additions, ordered easy → hard:
+Fabra implements about 25 of the ~200 ZPL commands. The original
+easy → hard plan below is complete; the full command set and what remains
+is catalogued under "ZPL command catalogue". Planned additions:
 
 - [x] `^FX` — Comment. New `Comment` type; renders `^FX{text}^FS`.
 - [x] `^LH` — Label Home. New `LabelHome` record (x, y); renders `^LH{x},{y}`.
@@ -64,6 +65,158 @@ for simple static labels. Planned additions, ordered easy → hard:
   - [x] Phase 2: image-to-bitmap converter in the `Fabra.Imaging` package
         (`ImageField.fromFile`/`fromStream`); luminance threshold (default)
         or Floyd–Steinberg dithering.
+
+## ZPL command catalogue
+
+Coverage of the ZPL II command set grouped by family. `[x]` = implemented,
+`[ ]` = not yet implemented. This lists the major commands and is not
+guaranteed exhaustive; consult the Zebra ZPL II Programming Guide for the
+authoritative spec and parameter details. New commands follow the five
+steps in "Adding a ZPL command" above.
+
+The `^XA`/`^XZ` start/end-format wrappers and the trailing `^FS` field
+separator are emitted automatically by the renderer and have no factory.
+
+### Fields & formatting
+
+- [x] `^FD` — Field Data
+- [x] `^FO` — Field Origin
+- [x] `^FB` — Field Block
+- [x] `^FR` — Field Reverse Print
+- [x] `^FH` — Field Hexadecimal Indicator
+- [x] `^FX` — Comment
+- [ ] `^FT` — Field Typeset
+- [ ] `^FV` — Field Variable
+- [ ] `^FW` — Field Orientation (default)
+- [ ] `^FN` — Field Number
+- [ ] `^FP` — Field Parameter (character spacing/direction)
+- [ ] `^FM` — Multiple Field Origin Locations
+- [ ] `^FC` — Field Clock (real-time clock)
+- [ ] `^FL` — Font Linking
+- [ ] `^CO` — Cache On
+
+### Fonts & text
+
+- [x] `^A` — Scalable/bitmap font
+- [x] `^CF` — Change Alphanumeric Default Font
+- [x] `^CI` — Change International Font/Encoding
+- [ ] `^A@` — Use named font
+- [ ] `^CW` — Font Identifier
+- [ ] `^SL` — Set Mode/Language (RTC)
+- [ ] `~DB` / `~DS` — Download bitmap / scalable font
+- [ ] `^TB` — Text Block
+
+### Bar codes
+
+- [x] `^BY` — Bar Code Field Default
+- [x] `^BC` — Code 128
+- [x] `^B2` — Interleaved 2 of 5
+- [x] `^B3` — Code 39
+- [x] `^BE` — EAN-13
+- [x] `^BU` — UPC-A
+- [x] `^BX` — Data Matrix
+- [x] `^BQ` — QR Code
+- [ ] `^B1` — Code 11
+- [ ] `^B4` — Code 49
+- [ ] `^B5` — Planet Code
+- [ ] `^B7` — PDF417
+- [ ] `^B8` — EAN-8
+- [ ] `^B9` — UPC-E
+- [ ] `^BA` — Code 93
+- [ ] `^BB` — CODABLOCK
+- [ ] `^BD` — UPS MaxiCode
+- [ ] `^BF` — Micro-PDF417
+- [ ] `^BI` — Industrial 2 of 5
+- [ ] `^BJ` — Standard 2 of 5
+- [ ] `^BK` — ANSI Codabar
+- [ ] `^BL` — LOGMARS
+- [ ] `^BM` — MSI
+- [ ] `^BO` — Aztec
+- [ ] `^BP` — Plessey
+- [ ] `^BR` — GS1 DataBar (RSS)
+- [ ] `^BS` — UPC/EAN extensions
+- [ ] `^BT` — TLC39
+- [ ] `^BZ` — POSTNET
+
+### Graphics
+
+- [x] `^GB` — Graphic Box
+- [x] `^GC` — Graphic Circle
+- [x] `^GD` — Graphic Diagonal Line
+- [x] `^GE` — Graphic Ellipse
+- [x] `^GF` — Graphic Field (see also `Fabra.Imaging`)
+- [ ] `^GS` — Graphic Symbol
+- [ ] `^IM` — Image Move
+- [ ] `^IL` — Image Load
+- [ ] `^IS` — Image Save
+- [ ] `~DG` / `~DY` — Download graphic / objects
+- [ ] `^XG` — Recall graphic
+
+### Label & format setup
+
+- [x] `^LH` — Label Home
+- [x] `^LL` — Label Length
+- [ ] `^LS` — Label Shift
+- [ ] `^LT` — Label Top
+- [ ] `^LR` — Label Reverse Print
+- [ ] `^PO` — Print Orientation (invert)
+- [ ] `^PM` — Print Mirror Image
+- [ ] `^PF` — Slew given number of dots
+- [ ] `^XF` — Recall format
+- [ ] `^XB` — Suppress Backfeed
+
+### Media & printer configuration
+
+- [x] `^MD` — Media Darkness
+- [x] `^PW` — Print Width
+- [x] `^PQ` — Print Quantity
+- [ ] `^PR` — Print Rate (speed)
+- [ ] `^MN` — Media Tracking
+- [ ] `^MT` — Media Type
+- [ ] `^MM` — Print Mode
+- [ ] `^MU` — Set Units
+- [ ] `^MF` — Media Feed (power-up/head-close)
+- [ ] `^ML` — Maximum Label Length
+- [ ] `^SS` — Set Media Sensors
+- [ ] `^CM` — Change Memory Letter Designation
+- [ ] `^CC` / `~CC` — Change Caret prefix
+- [ ] `^CD` / `~CD` — Change Delimiter
+- [ ] `^CT` / `~CT` — Change Tilde prefix
+
+### Serialization, clock & data
+
+- [ ] `^SN` — Serialization Data
+- [ ] `^SF` — Serialization Field
+- [ ] `^ST` — Set Date and Time (RTC)
+- [ ] `^SE` — Select Encoding table
+
+### Control (`~`) commands
+
+- [ ] `~SD` — Set Darkness
+- [ ] `~JA` — Cancel All
+- [ ] `~JL` — Set Label Length
+- [ ] `~JR` — Power-On Reset
+- [ ] `~JS` — Change Backfeed Sequence
+- [ ] `~JX` — Cancel Current Format
+- [ ] `~PS` / `~PP` — Print Start / Pause
+- [ ] `~HS` — Host Status Return
+- [ ] `~HI` — Host Identification
+- [ ] `~HM` — Host Memory Status
+- [ ] `~WC` — Print Configuration Label
+
+### RFID (`^R` / `~R`)
+
+- [ ] `^RS` — RFID Setup
+- [ ] `^RF` — RFID Read/Write
+- [ ] `^RB` — Define EPC Data Structure
+- [ ] `^RI` — Get RFID Tag ID
+- [ ] `^RM` — Enable RFID Motion
+- [ ] `^RR` — Specify RFID Retries
+- [ ] `^RT` — Read RFID Tag
+- [ ] `^RW` — Set RFID Read/Write Power
+- [ ] `^RZ` — Set RFID Tag Password
+- [ ] `~RV` — Report RFID Validation
+- [ ] `^WV` — Verify RFID Write
 
 ## Open design items
 

--- a/Label.fs
+++ b/Label.fs
@@ -47,6 +47,51 @@ module internal Render =
                 | LabelHome lh ->
                     sb.AppendLine(lh.ToString()) |> ignore
                     loop tail sb
+                | ChangeFont cf ->
+                    sb.AppendLine(cf.ToString()) |> ignore
+                    loop tail sb
+                | FieldReverse ->
+                    sb.AppendLine("^FR") |> ignore
+                    loop tail sb
+                | FieldHexadecimal fh ->
+                    sb.AppendLine(fh.ToString()) |> ignore
+                    loop tail sb
+                | ChangeInternational ci ->
+                    sb.AppendLine(ci.ToString()) |> ignore
+                    loop tail sb
+                | LabelLength ll ->
+                    sb.AppendLine(ll.ToString()) |> ignore
+                    loop tail sb
+                | PrintWidth pw ->
+                    sb.AppendLine(pw.ToString()) |> ignore
+                    loop tail sb
+                | MediaDarkness md ->
+                    sb.AppendLine(md.ToString()) |> ignore
+                    loop tail sb
+                | PrintQuantity pq ->
+                    sb.AppendLine(pq.ToString()) |> ignore
+                    loop tail sb
+                | GraphicCircle gc ->
+                    sb.AppendLine(gc.ToString()) |> ignore
+                    loop tail sb
+                | GraphicDiagonal gd ->
+                    sb.AppendLine(gd.ToString()) |> ignore
+                    loop tail sb
+                | GraphicEllipse ge ->
+                    sb.AppendLine(ge.ToString()) |> ignore
+                    loop tail sb
+                | Code39 c39 ->
+                    sb.AppendLine(c39.ToString()) |> ignore
+                    loop tail sb
+                | Interleaved2of5 i25 ->
+                    sb.AppendLine(i25.ToString()) |> ignore
+                    loop tail sb
+                | Ean13 e13 ->
+                    sb.AppendLine(e13.ToString()) |> ignore
+                    loop tail sb
+                | UpcA upc ->
+                    sb.AppendLine(upc.ToString()) |> ignore
+                    loop tail sb
                 | Collection co ->
                     loop (List.append co tail) sb
 
@@ -292,6 +337,199 @@ type Label =
   static member inline LH x y =
     { LabelHome.X_Axis = x; Y_Axis = y }
     |> LabelElement.LabelHome
+
+  /// <summary>
+  /// Change Alphanumeric Default Font (^CF)
+  ///
+  /// Sets the default font, character height and width used by ^FD fields
+  /// that do not specify their own ^A font.
+  /// </summary>
+  /// <param name="f">Default font identifier (A-Z or 0-9)</param>
+  /// <param name="h">Character height (in dots)</param>
+  /// <param name="w">Character width (in dots)</param>
+  /// <returns>LabelElement.ChangeFont</returns>
+  static member inline CF f h w =
+    { ChangeFont.Font = f; Height = h; Width = w }
+    |> LabelElement.ChangeFont
+
+  /// <summary>
+  /// Field Reverse Print (^FR)
+  ///
+  /// Reverses the print colour of the field it precedes (white on black,
+  /// or vice versa). Emitted before the field's ^FD.
+  /// </summary>
+  /// <returns>LabelElement.FieldReverse</returns>
+  static member FR = LabelElement.FieldReverse
+
+  /// <summary>
+  /// Field Hexadecimal Indicator (^FH)
+  ///
+  /// Lets the following ^FD encode non-printable characters as hex escapes.
+  /// </summary>
+  /// <param name="c">Escape indicator character (ZPL default is '_')</param>
+  /// <returns>LabelElement.FieldHexadecimal</returns>
+  static member inline FH c =
+    FieldHexadecimal.FieldHexadecimal c
+    |> LabelElement.FieldHexadecimal
+
+  /// <summary>
+  /// Change International Font/Encoding (^CI)
+  /// </summary>
+  /// <param name="n">Character set. Values: 0 to 36 (e.g. 28 = UTF-8)</param>
+  /// <returns>LabelElement.ChangeInternational</returns>
+  static member inline CI n =
+    ChangeInternational.ChangeInternational n
+    |> LabelElement.ChangeInternational
+
+  /// <summary>
+  /// Label Length (^LL)
+  /// </summary>
+  /// <param name="y">Label length (in dots)</param>
+  /// <returns>LabelElement.LabelLength</returns>
+  static member inline LL y =
+    LabelLength.LabelLength y
+    |> LabelElement.LabelLength
+
+  /// <summary>
+  /// Print Width (^PW)
+  /// </summary>
+  /// <param name="a">Label width (in dots)</param>
+  /// <returns>LabelElement.PrintWidth</returns>
+  static member inline PW a =
+    PrintWidth.PrintWidth a
+    |> LabelElement.PrintWidth
+
+  /// <summary>
+  /// Media Darkness (^MD)
+  /// </summary>
+  /// <param name="a">Darkness adjustment. Values: -30 to 30</param>
+  /// <returns>LabelElement.MediaDarkness</returns>
+  static member inline MD a =
+    MediaDarkness.MediaDarkness a
+    |> LabelElement.MediaDarkness
+
+  /// <summary>
+  /// Print Quantity (^PQ)
+  /// </summary>
+  /// <param name="q">Total quantity of labels to print</param>
+  /// <param name="p">Pause-and-cut count (labels printed before a pause)</param>
+  /// <param name="r">Replicates of each serial number</param>
+  /// <param name="e">Override pause count</param>
+  /// <param name="o">Cut on error label</param>
+  /// <returns>LabelElement.PrintQuantity</returns>
+  static member inline PQ q p r e o =
+    { PrintQuantity.Quantity = q; Pause = p; Replicates = r; OverridePause = e; CutOnError = o }
+    |> LabelElement.PrintQuantity
+
+  /// <summary>
+  /// Graphic Circle (^GC)
+  /// </summary>
+  /// <param name="d">Circle diameter (in dots)</param>
+  /// <param name="t">Border thickness (in dots)</param>
+  /// <param name="c">Line colour</param>
+  /// <returns>LabelElement.GraphicCircle</returns>
+  static member inline GC d t c =
+    { GraphicCircle.Diameter = d; Thickness = t; LineColour = c }
+    |> LabelElement.GraphicCircle
+
+  /// <summary>
+  /// Graphic Diagonal Line (^GD)
+  /// </summary>
+  /// <param name="w">Bounding box width (in dots)</param>
+  /// <param name="h">Bounding box height (in dots)</param>
+  /// <param name="t">Border thickness (in dots)</param>
+  /// <param name="c">Line colour</param>
+  /// <param name="o">Diagonal direction (R = '\', L = '/')</param>
+  /// <returns>LabelElement.GraphicDiagonal</returns>
+  static member inline GD w h t c o =
+    { GraphicDiagonal.Width = w; Height = h; Thickness = t; LineColour = c; Orientation = o }
+    |> LabelElement.GraphicDiagonal
+
+  /// <summary>
+  /// Graphic Ellipse (^GE)
+  /// </summary>
+  /// <param name="w">Ellipse width (in dots)</param>
+  /// <param name="h">Ellipse height (in dots)</param>
+  /// <param name="t">Border thickness (in dots)</param>
+  /// <param name="c">Line colour</param>
+  /// <returns>LabelElement.GraphicEllipse</returns>
+  static member inline GE w h t c =
+    { GraphicEllipse.Width = w; Height = h; Thickness = t; LineColour = c }
+    |> LabelElement.GraphicEllipse
+
+  /// <summary>
+  /// Code 39 Bar Code (^B3)
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="e">Mod-43 check digit</param>
+  /// <param name="h">Bar code height (in dots)</param>
+  /// <param name="f">Print interpretation line</param>
+  /// <param name="g">Print interpretation line above code</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.Code39</returns>
+  static member inline B3 o e h f g (fd: string) =
+    { Code39.Orientation = o
+      CheckDigit = e
+      Height = h
+      PrintInterpretationLine = f
+      PrintInterpretationLineAboveCode = g
+      Data = FieldData.FieldData fd }
+    |> LabelElement.Code39
+
+  /// <summary>
+  /// Interleaved 2 of 5 Bar Code (^B2)
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="h">Bar code height (in dots)</param>
+  /// <param name="f">Print interpretation line</param>
+  /// <param name="g">Print interpretation line above code</param>
+  /// <param name="e">Calculate and print mod-10 check digit</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.Interleaved2of5</returns>
+  static member inline B2 o h f g e (fd: string) =
+    { Interleaved2of5.Orientation = o
+      Height = h
+      PrintInterpretationLine = f
+      PrintInterpretationLineAboveCode = g
+      CheckDigit = e
+      Data = FieldData.FieldData fd }
+    |> LabelElement.Interleaved2of5
+
+  /// <summary>
+  /// EAN-13 Bar Code (^BE)
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="h">Bar code height (in dots)</param>
+  /// <param name="f">Print interpretation line</param>
+  /// <param name="g">Print interpretation line above code</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.Ean13</returns>
+  static member inline BE o h f g (fd: string) =
+    { Ean13.Orientation = o
+      Height = h
+      PrintInterpretationLine = f
+      PrintInterpretationLineAboveCode = g
+      Data = FieldData.FieldData fd }
+    |> LabelElement.Ean13
+
+  /// <summary>
+  /// UPC-A Bar Code (^BU)
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="h">Bar code height (in dots)</param>
+  /// <param name="f">Print interpretation line</param>
+  /// <param name="g">Print interpretation line above code</param>
+  /// <param name="e">Print check digit</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.UpcA</returns>
+  static member inline BU o h f g e (fd: string) =
+    { UpcA.Orientation = o
+      Height = h
+      PrintInterpretationLine = f
+      PrintInterpretationLineAboveCode = g
+      PrintCheckDigit = e
+      Data = FieldData.FieldData fd }
+    |> LabelElement.UpcA
 
   static member inline Collection lst = LabelElement.Collection lst
 

--- a/Label.fs
+++ b/Label.fs
@@ -359,7 +359,7 @@ type Label =
   /// or vice versa). Emitted before the field's ^FD.
   /// </summary>
   /// <returns>LabelElement.FieldReverse</returns>
-  static member FR = LabelElement.FieldReverse
+  static member inline FR = LabelElement.FieldReverse
 
   /// <summary>
   /// Field Hexadecimal Indicator (^FH)
@@ -442,7 +442,7 @@ type Label =
   /// <param name="o">Diagonal direction (R = '\', L = '/')</param>
   /// <returns>LabelElement.GraphicDiagonal</returns>
   static member inline GD w h t c o =
-    { GraphicDiagonal.Width = w; Height = h; Thickness = t; LineColour = c; Orientation = o }
+    { GraphicDiagonal.Width = w; Height = h; Thickness = t; LineColour = c; Direction = o }
     |> LabelElement.GraphicDiagonal
 
   /// <summary>

--- a/Types.fs
+++ b/Types.fs
@@ -353,9 +353,9 @@ type GraphicDiagonal =
       Height: int
       Thickness: int
       LineColour: LineColour
-      Orientation: Diagonal }
+      Direction: Diagonal }
     override x.ToString() =
-        $"^GD{x.Width},{x.Height},{x.Thickness},{x.LineColour},{x.Orientation}^FS"
+        $"^GD{x.Width},{x.Height},{x.Thickness},{x.LineColour},{x.Direction}^FS"
 
 /// Graphic Ellipse (^GE)
 type GraphicEllipse =

--- a/Types.fs
+++ b/Types.fs
@@ -94,6 +94,18 @@ type LineColour =
     | LineColour.B -> "B"
     | LineColour.W -> "W"
 
+/// Diagonal orientation for the Graphic Diagonal Line (^GD) command.
+[<RequireQualifiedAccess>]
+type Diagonal =
+  /// Right-leaning diagonal, '\' (default).
+  | R
+  /// Left-leaning diagonal, '/'.
+  | L
+  override x.ToString() =
+    match x with
+    | Diagonal.R -> "R"
+    | Diagonal.L -> "L"
+
 /// Field Data (^FD)
 type FieldData =
     | FieldData of string
@@ -275,6 +287,128 @@ type LabelHome =
       Y_Axis: int }
     override x.ToString() = $"^LH{x.X_Axis},{x.Y_Axis}"
 
+/// Change Alphanumeric Default Font (^CF)
+type ChangeFont =
+    { Font: Font
+      Height: int
+      Width: int }
+    override x.ToString() = $"^CF{x.Font},{x.Height},{x.Width}"
+
+/// Field Hexadecimal Indicator (^FH)
+type FieldHexadecimal =
+    | FieldHexadecimal of char
+    override x.ToString() =
+        let (FieldHexadecimal c) = x
+        $"^FH{c}"
+
+/// Change International Font/Encoding (^CI)
+type ChangeInternational =
+    | ChangeInternational of int
+    override x.ToString() =
+        let (ChangeInternational n) = x
+        $"^CI{n}"
+
+/// Label Length (^LL)
+type LabelLength =
+    | LabelLength of int
+    override x.ToString() =
+        let (LabelLength n) = x
+        $"^LL{n}"
+
+/// Print Width (^PW)
+type PrintWidth =
+    | PrintWidth of int
+    override x.ToString() =
+        let (PrintWidth n) = x
+        $"^PW{n}"
+
+/// Media Darkness (^MD)
+type MediaDarkness =
+    | MediaDarkness of int
+    override x.ToString() =
+        let (MediaDarkness n) = x
+        $"^MD{n}"
+
+/// Print Quantity (^PQ)
+type PrintQuantity =
+    { Quantity: int
+      Pause: int
+      Replicates: int
+      OverridePause: YesNo
+      CutOnError: YesNo }
+    override x.ToString() =
+        $"^PQ{x.Quantity},{x.Pause},{x.Replicates},{x.OverridePause},{x.CutOnError}"
+
+/// Graphic Circle (^GC)
+type GraphicCircle =
+    { Diameter: int
+      Thickness: int
+      LineColour: LineColour }
+    override x.ToString() =
+        $"^GC{x.Diameter},{x.Thickness},{x.LineColour}^FS"
+
+/// Graphic Diagonal Line (^GD)
+type GraphicDiagonal =
+    { Width: int
+      Height: int
+      Thickness: int
+      LineColour: LineColour
+      Orientation: Diagonal }
+    override x.ToString() =
+        $"^GD{x.Width},{x.Height},{x.Thickness},{x.LineColour},{x.Orientation}^FS"
+
+/// Graphic Ellipse (^GE)
+type GraphicEllipse =
+    { Width: int
+      Height: int
+      Thickness: int
+      LineColour: LineColour }
+    override x.ToString() =
+        $"^GE{x.Width},{x.Height},{x.Thickness},{x.LineColour}^FS"
+
+/// Code 39 Bar Code (^B3)
+type Code39 =
+    { Orientation: Orientation
+      CheckDigit: YesNo
+      Height: int
+      PrintInterpretationLine: YesNo
+      PrintInterpretationLineAboveCode: YesNo
+      Data: FieldData }
+    override x.ToString() =
+        $"^B3{x.Orientation},{x.CheckDigit},{x.Height},{x.PrintInterpretationLine},{x.PrintInterpretationLineAboveCode}{x.Data}"
+
+/// Interleaved 2 of 5 Bar Code (^B2)
+type Interleaved2of5 =
+    { Orientation: Orientation
+      Height: int
+      PrintInterpretationLine: YesNo
+      PrintInterpretationLineAboveCode: YesNo
+      CheckDigit: YesNo
+      Data: FieldData }
+    override x.ToString() =
+        $"^B2{x.Orientation},{x.Height},{x.PrintInterpretationLine},{x.PrintInterpretationLineAboveCode},{x.CheckDigit}{x.Data}"
+
+/// EAN-13 Bar Code (^BE)
+type Ean13 =
+    { Orientation: Orientation
+      Height: int
+      PrintInterpretationLine: YesNo
+      PrintInterpretationLineAboveCode: YesNo
+      Data: FieldData }
+    override x.ToString() =
+        $"^BE{x.Orientation},{x.Height},{x.PrintInterpretationLine},{x.PrintInterpretationLineAboveCode}{x.Data}"
+
+/// UPC-A Bar Code (^BU)
+type UpcA =
+    { Orientation: Orientation
+      Height: int
+      PrintInterpretationLine: YesNo
+      PrintInterpretationLineAboveCode: YesNo
+      PrintCheckDigit: YesNo
+      Data: FieldData }
+    override x.ToString() =
+        $"^BU{x.Orientation},{x.Height},{x.PrintInterpretationLine},{x.PrintInterpretationLineAboveCode},{x.PrintCheckDigit}{x.Data}"
+
 /// A label element/command.
 /// Used for containing all label commands within a single collection/label.
 type LabelElement =
@@ -290,4 +424,19 @@ type LabelElement =
     | BarcodeFieldDefault of BarcodeFieldDefault
     | Comment of Comment
     | LabelHome of LabelHome
+    | ChangeFont of ChangeFont
+    | FieldReverse
+    | FieldHexadecimal of FieldHexadecimal
+    | ChangeInternational of ChangeInternational
+    | LabelLength of LabelLength
+    | PrintWidth of PrintWidth
+    | MediaDarkness of MediaDarkness
+    | PrintQuantity of PrintQuantity
+    | GraphicCircle of GraphicCircle
+    | GraphicDiagonal of GraphicDiagonal
+    | GraphicEllipse of GraphicEllipse
+    | Code39 of Code39
+    | Interleaved2of5 of Interleaved2of5
+    | Ean13 of Ean13
+    | UpcA of UpcA
     | Collection of LabelElement list

--- a/tests/Fabra.Tests/GoldenTests.fs
+++ b/tests/Fabra.Tests/GoldenTests.fs
@@ -92,3 +92,63 @@ module GoldenTests =
     let ``^GF renders pre-encoded ASCII-hex graphic data`` () =
         let zpl = ZPL.render (Label [ Label.GF 8 8 2 "FF00FF00FF00FF00" ])
         Assert.Contains("^GFA,8,8,2,FF00FF00FF00FF00^FS", zpl)
+
+    [<Fact>]
+    let ``^CF sets the default font`` () =
+        Assert.Contains("^CF0,30,30", ZPL.render (Label [ Label.CF (Font '0') 30 30 ]))
+
+    [<Fact>]
+    let ``^FR renders field reverse`` () =
+        Assert.Contains("^FR", ZPL.render (Label [ Label.FR ]))
+
+    [<Fact>]
+    let ``^FH renders the hex indicator`` () =
+        Assert.Contains("^FH_", ZPL.render (Label [ Label.FH '_' ]))
+
+    [<Fact>]
+    let ``^CI sets the international encoding`` () =
+        Assert.Contains("^CI28", ZPL.render (Label [ Label.CI 28 ]))
+
+    [<Fact>]
+    let ``^LL sets the label length`` () =
+        Assert.Contains("^LL1200", ZPL.render (Label [ Label.LL 1200 ]))
+
+    [<Fact>]
+    let ``^PW sets the print width`` () =
+        Assert.Contains("^PW800", ZPL.render (Label [ Label.PW 800 ]))
+
+    [<Fact>]
+    let ``^MD sets the media darkness`` () =
+        Assert.Contains("^MD10", ZPL.render (Label [ Label.MD 10 ]))
+
+    [<Fact>]
+    let ``^PQ sets the print quantity`` () =
+        Assert.Contains("^PQ3,0,0,N,Y", ZPL.render (Label [ Label.PQ 3 0 0 YesNo.N YesNo.Y ]))
+
+    [<Fact>]
+    let ``^GC renders a circle`` () =
+        Assert.Contains("^GC100,4,B^FS", ZPL.render (Label [ Label.GC 100 4 LineColour.B ]))
+
+    [<Fact>]
+    let ``^GD renders a diagonal line`` () =
+        Assert.Contains("^GD100,100,2,B,R^FS", ZPL.render (Label [ Label.GD 100 100 2 LineColour.B Diagonal.R ]))
+
+    [<Fact>]
+    let ``^GE renders an ellipse`` () =
+        Assert.Contains("^GE120,60,3,B^FS", ZPL.render (Label [ Label.GE 120 60 3 LineColour.B ]))
+
+    [<Fact>]
+    let ``^B3 renders a Code 39 barcode`` () =
+        Assert.Contains("^B3N,N,100,Y,N^FD123ABC^FS", ZPL.render (Label [ Label.B3 Orientation.N YesNo.N 100 YesNo.Y YesNo.N "123ABC" ]))
+
+    [<Fact>]
+    let ``^B2 renders an Interleaved 2 of 5 barcode`` () =
+        Assert.Contains("^B2N,100,Y,N,N^FD1234^FS", ZPL.render (Label [ Label.B2 Orientation.N 100 YesNo.Y YesNo.N YesNo.N "1234" ]))
+
+    [<Fact>]
+    let ``^BE renders an EAN-13 barcode`` () =
+        Assert.Contains("^BEN,100,Y,N^FD123456789012^FS", ZPL.render (Label [ Label.BE Orientation.N 100 YesNo.Y YesNo.N "123456789012" ]))
+
+    [<Fact>]
+    let ``^BU renders a UPC-A barcode`` () =
+        Assert.Contains("^BUN,100,Y,N,Y^FD12345678901^FS", ZPL.render (Label [ Label.BU Orientation.N 100 YesNo.Y YesNo.N YesNo.Y "12345678901" ]))


### PR DESCRIPTION
## Summary

Implements a curated batch of **15 commonly-needed ZPL commands** (following the existing positional factory pattern) and **documents the complete ZPL II command set** in `CLAUDE.md` so the remaining work is catalogued. This was scoped deliberately: implementing all ~190 remaining commands in one PR isn't feasible to do correctly, so this delivers a high-value, fully-tested batch plus a roadmap of the rest.

### Commands implemented (each: domain type → `LabelElement` case → `Label.*` factory → render branch → test)

| Family | Commands |
|--------|----------|
| Bar codes | `^B3` Code 39, `^B2` Interleaved 2 of 5, `^BE` EAN-13, `^BU` UPC-A |
| Graphics | `^GC` circle, `^GD` diagonal line, `^GE` ellipse |
| Fields / fonts | `^CF` default font, `^FR` field reverse, `^FH` hex indicator, `^CI` encoding |
| Printer / label setup | `^LL` label length, `^PW` print width, `^PQ` print quantity, `^MD` media darkness |

One small new enum (`Diagonal`, `R`/`L`) supports `^GD`; everything else reuses the existing `Orientation`, `YesNo`, `LineColour`, `Font`, and `FieldData` types. `^FR` is modelled as a payload-less `LabelElement` case (renders bare `^FR`).

### Documentation

`CLAUDE.md` gains a **"ZPL command catalogue"** section: every major command grouped by family (fields, fonts/text, bar codes, graphics, label/format setup, media/printer config, serialization, control `~` commands, RFID) with `[x]`/`[ ]` status. The roadmap intro is updated (~25 of ~200 implemented).

## Notes

- No input validation, per the existing library convention (tracked as an open design item).
- Catalogue covers the major commands and is explicitly noted as not guaranteed exhaustive — the Zebra ZPL II Programming Guide remains the authoritative spec.

## Test plan

- [x] `dotnet build Fabra.sln -c Release` — clean, 0 warnings
- [x] `dotnet test Fabra.sln` — 31/31 passing (15 new rendering tests)
- [x] Existing golden files unchanged

https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN)_