### PR TITLE
Add 21 more ZPL commands and extend the catalogue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Each command follows the same pattern:
 
 ## ZPL command roadmap
 
-Fabra implements about 25 of the ~200 ZPL commands. The original
+Fabra implements about 37 of the ~200 ZPL commands. The original
 easy → hard plan below is complete; the full command set and what remains
 is catalogued under "ZPL command catalogue". Planned additions:
 
@@ -85,9 +85,9 @@ separator are emitted automatically by the renderer and have no factory.
 - [x] `^FR` — Field Reverse Print
 - [x] `^FH` — Field Hexadecimal Indicator
 - [x] `^FX` — Comment
-- [ ] `^FT` — Field Typeset
-- [ ] `^FV` — Field Variable
-- [ ] `^FW` — Field Orientation (default)
+- [x] `^FT` — Field Typeset
+- [x] `^FV` — Field Variable
+- [x] `^FW` — Field Orientation (default)
 - [ ] `^FN` — Field Number
 - [ ] `^FP` — Field Parameter (character spacing/direction)
 - [ ] `^FM` — Multiple Field Origin Locations
@@ -116,13 +116,13 @@ separator are emitted automatically by the renderer and have no factory.
 - [x] `^BU` — UPC-A
 - [x] `^BX` — Data Matrix
 - [x] `^BQ` — QR Code
-- [ ] `^B1` — Code 11
+- [x] `^B1` — Code 11
+- [x] `^B7` — PDF417
+- [x] `^B8` — EAN-8
+- [x] `^B9` — UPC-E
+- [x] `^BA` — Code 93
 - [ ] `^B4` — Code 49
 - [ ] `^B5` — Planet Code
-- [ ] `^B7` — PDF417
-- [ ] `^B8` — EAN-8
-- [ ] `^B9` — UPC-E
-- [ ] `^BA` — Code 93
 - [ ] `^BB` — CODABLOCK
 - [ ] `^BD` — UPS MaxiCode
 - [ ] `^BF` — Micro-PDF417
@@ -156,10 +156,10 @@ separator are emitted automatically by the renderer and have no factory.
 
 - [x] `^LH` — Label Home
 - [x] `^LL` — Label Length
-- [ ] `^LS` — Label Shift
-- [ ] `^LT` — Label Top
+- [x] `^LS` — Label Shift
+- [x] `^LT` — Label Top
+- [x] `^PO` — Print Orientation (invert)
 - [ ] `^LR` — Label Reverse Print
-- [ ] `^PO` — Print Orientation (invert)
 - [ ] `^PM` — Print Mirror Image
 - [ ] `^PF` — Slew given number of dots
 - [ ] `^XF` — Recall format
@@ -170,9 +170,9 @@ separator are emitted automatically by the renderer and have no factory.
 - [x] `^MD` — Media Darkness
 - [x] `^PW` — Print Width
 - [x] `^PQ` — Print Quantity
+- [x] `^MT` — Media Type
 - [ ] `^PR` — Print Rate (speed)
 - [ ] `^MN` — Media Tracking
-- [ ] `^MT` — Media Type
 - [ ] `^MM` — Print Mode
 - [ ] `^MU` — Set Units
 - [ ] `^MF` — Media Feed (power-up/head-close)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Each command follows the same pattern:
 
 ## ZPL command roadmap
 
-Fabra implements about 37 of the ~200 ZPL commands. The original
+Fabra implements about 46 of the ~200 ZPL commands. The original
 easy → hard plan below is complete; the full command set and what remains
 is catalogued under "ZPL command catalogue". Planned additions:
 
@@ -88,8 +88,8 @@ separator are emitted automatically by the renderer and have no factory.
 - [x] `^FT` — Field Typeset
 - [x] `^FV` — Field Variable
 - [x] `^FW` — Field Orientation (default)
-- [ ] `^FN` — Field Number
-- [ ] `^FP` — Field Parameter (character spacing/direction)
+- [x] `^FN` — Field Number
+- [x] `^FP` — Field Parameter (character spacing/direction)
 - [ ] `^FM` — Multiple Field Origin Locations
 - [ ] `^FC` — Field Clock (real-time clock)
 - [ ] `^FL` — Font Linking
@@ -128,11 +128,11 @@ separator are emitted automatically by the renderer and have no factory.
 - [ ] `^BF` — Micro-PDF417
 - [ ] `^BI` — Industrial 2 of 5
 - [ ] `^BJ` — Standard 2 of 5
-- [ ] `^BK` — ANSI Codabar
+- [x] `^BK` — ANSI Codabar
+- [x] `^BO` — Aztec
+- [x] `^BP` — Plessey
 - [ ] `^BL` — LOGMARS
 - [ ] `^BM` — MSI
-- [ ] `^BO` — Aztec
-- [ ] `^BP` — Plessey
 - [ ] `^BR` — GS1 DataBar (RSS)
 - [ ] `^BS` — UPC/EAN extensions
 - [ ] `^BT` — TLC39
@@ -145,7 +145,7 @@ separator are emitted automatically by the renderer and have no factory.
 - [x] `^GD` — Graphic Diagonal Line
 - [x] `^GE` — Graphic Ellipse
 - [x] `^GF` — Graphic Field (see also `Fabra.Imaging`)
-- [ ] `^GS` — Graphic Symbol
+- [x] `^GS` — Graphic Symbol
 - [ ] `^IM` — Image Move
 - [ ] `^IL` — Image Load
 - [ ] `^IS` — Image Save
@@ -159,9 +159,9 @@ separator are emitted automatically by the renderer and have no factory.
 - [x] `^LS` — Label Shift
 - [x] `^LT` — Label Top
 - [x] `^PO` — Print Orientation (invert)
-- [ ] `^LR` — Label Reverse Print
-- [ ] `^PM` — Print Mirror Image
-- [ ] `^PF` — Slew given number of dots
+- [x] `^LR` — Label Reverse Print
+- [x] `^PM` — Print Mirror Image
+- [x] `^PF` — Slew given number of dots
 - [ ] `^XF` — Recall format
 - [ ] `^XB` — Suppress Backfeed
 

--- a/Label.fs
+++ b/Label.fs
@@ -92,6 +92,42 @@ module internal Render =
                 | UpcA upc ->
                     sb.AppendLine(upc.ToString()) |> ignore
                     loop tail sb
+                | Ean8 b8 ->
+                    sb.AppendLine(b8.ToString()) |> ignore
+                    loop tail sb
+                | UpcE b9 ->
+                    sb.AppendLine(b9.ToString()) |> ignore
+                    loop tail sb
+                | Code93 ba ->
+                    sb.AppendLine(ba.ToString()) |> ignore
+                    loop tail sb
+                | Code11 b1 ->
+                    sb.AppendLine(b1.ToString()) |> ignore
+                    loop tail sb
+                | Pdf417 b7 ->
+                    sb.AppendLine(b7.ToString()) |> ignore
+                    loop tail sb
+                | FieldTypeset ft ->
+                    sb.AppendLine(ft.ToString()) |> ignore
+                    loop tail sb
+                | FieldVariable fv ->
+                    sb.AppendLine(fv.ToString()) |> ignore
+                    loop tail sb
+                | FieldOrientation fw ->
+                    sb.AppendLine(fw.ToString()) |> ignore
+                    loop tail sb
+                | PrintOrientation po ->
+                    sb.AppendLine(po.ToString()) |> ignore
+                    loop tail sb
+                | LabelShift ls ->
+                    sb.AppendLine(ls.ToString()) |> ignore
+                    loop tail sb
+                | LabelTop lt ->
+                    sb.AppendLine(lt.ToString()) |> ignore
+                    loop tail sb
+                | MediaType mt ->
+                    sb.AppendLine(mt.ToString()) |> ignore
+                    loop tail sb
                 | Collection co ->
                     loop (List.append co tail) sb
 
@@ -257,7 +293,7 @@ type Label =
   /// <param name="z">Justification. Values: 0 = left justification, 1 = right justification, 2 = auto justification (script dependent). Default: last accepted ^FW value or ^FW default</param>
   /// <returns>LabelElement.FieldOrigin</returns>
   static member inline FO x y z =
-    { X_Axis = x; Y_Axis = y; Z = z }
+    { FieldOrigin.X_Axis = x; Y_Axis = y; Z = z }
     |> LabelElement.FieldOrigin
 
   /// <summary>
@@ -530,6 +566,170 @@ type Label =
       PrintCheckDigit = e
       Data = FieldData.FieldData fd }
     |> LabelElement.UpcA
+
+  /// <summary>
+  /// EAN-8 Bar Code (^B8)
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="h">Bar code height (in dots)</param>
+  /// <param name="f">Print interpretation line</param>
+  /// <param name="g">Print interpretation line above code</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.Ean8</returns>
+  static member inline B8 o h f g (fd: string) =
+    { Ean8.Orientation = o
+      Height = h
+      PrintInterpretationLine = f
+      PrintInterpretationLineAboveCode = g
+      Data = FieldData.FieldData fd }
+    |> LabelElement.Ean8
+
+  /// <summary>
+  /// UPC-E Bar Code (^B9)
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="h">Bar code height (in dots)</param>
+  /// <param name="f">Print interpretation line</param>
+  /// <param name="g">Print interpretation line above code</param>
+  /// <param name="e">Print check digit</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.UpcE</returns>
+  static member inline B9 o h f g e (fd: string) =
+    { UpcE.Orientation = o
+      Height = h
+      PrintInterpretationLine = f
+      PrintInterpretationLineAboveCode = g
+      PrintCheckDigit = e
+      Data = FieldData.FieldData fd }
+    |> LabelElement.UpcE
+
+  /// <summary>
+  /// Code 93 Bar Code (^BA)
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="h">Bar code height (in dots)</param>
+  /// <param name="f">Print interpretation line</param>
+  /// <param name="g">Print interpretation line above code</param>
+  /// <param name="e">Print check digit</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.Code93</returns>
+  static member inline BA o h f g e (fd: string) =
+    { Code93.Orientation = o
+      Height = h
+      PrintInterpretationLine = f
+      PrintInterpretationLineAboveCode = g
+      PrintCheckDigit = e
+      Data = FieldData.FieldData fd }
+    |> LabelElement.Code93
+
+  /// <summary>
+  /// Code 11 Bar Code (^B1)
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="e">Check digit</param>
+  /// <param name="h">Bar code height (in dots)</param>
+  /// <param name="f">Print interpretation line</param>
+  /// <param name="g">Print interpretation line above code</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.Code11</returns>
+  static member inline B1 o e h f g (fd: string) =
+    { Code11.Orientation = o
+      CheckDigit = e
+      Height = h
+      PrintInterpretationLine = f
+      PrintInterpretationLineAboveCode = g
+      Data = FieldData.FieldData fd }
+    |> LabelElement.Code11
+
+  /// <summary>
+  /// PDF417 Bar Code (^B7)
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="h">Row height (in dots)</param>
+  /// <param name="s">Security (error correction) level. Values: 0 to 8</param>
+  /// <param name="c">Number of data columns. Values: 1 to 30</param>
+  /// <param name="r">Number of rows. Values: 3 to 90</param>
+  /// <param name="t">Truncate right row indicators and stop pattern</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.Pdf417</returns>
+  static member inline B7 o h s c r t (fd: string) =
+    { Pdf417.Orientation = o
+      Height = h
+      SecurityLevel = s
+      Columns = c
+      Rows = r
+      Truncate = t
+      Data = FieldData.FieldData fd }
+    |> LabelElement.Pdf417
+
+  /// <summary>
+  /// Field Typeset (^FT)
+  ///
+  /// Like ^FO, but the field is positioned relative to a typeset baseline.
+  /// </summary>
+  /// <param name="x">X-axis location (in dots)</param>
+  /// <param name="y">Y-axis location (in dots)</param>
+  /// <param name="z">Justification</param>
+  /// <returns>LabelElement.FieldTypeset</returns>
+  static member inline FT x y z =
+    { FieldTypeset.X_Axis = x; Y_Axis = y; Z = z }
+    |> LabelElement.FieldTypeset
+
+  /// <summary>
+  /// Field Variable (^FV)
+  ///
+  /// Like ^FD, but the data prints only if a variable field is defined.
+  /// </summary>
+  /// <param name="s">Variable field data</param>
+  /// <returns>LabelElement.FieldVariable</returns>
+  static member inline FV s =
+    FieldVariable.FieldVariable s
+    |> LabelElement.FieldVariable
+
+  /// <summary>
+  /// Field Orientation default (^FW)
+  ///
+  /// Sets the default orientation for fields that follow.
+  /// </summary>
+  /// <param name="o">Default field orientation</param>
+  /// <returns>LabelElement.FieldOrientation</returns>
+  static member inline FW o =
+    FieldOrientation.FieldOrientation o
+    |> LabelElement.FieldOrientation
+
+  /// <summary>
+  /// Print Orientation (^PO)
+  ///
+  /// Inverts the label format 180 degrees (or leaves it normal).
+  /// </summary>
+  /// <param name="p">Print orientation (Normal or Invert)</param>
+  /// <returns>LabelElement.PrintOrientation</returns>
+  static member inline PO p = LabelElement.PrintOrientation p
+
+  /// <summary>
+  /// Label Shift (^LS)
+  /// </summary>
+  /// <param name="a">Left-shift amount applied to the whole label (in dots)</param>
+  /// <returns>LabelElement.LabelShift</returns>
+  static member inline LS a =
+    LabelShift.LabelShift a
+    |> LabelElement.LabelShift
+
+  /// <summary>
+  /// Label Top (^LT)
+  /// </summary>
+  /// <param name="x">Vertical shift of the whole label (in dots)</param>
+  /// <returns>LabelElement.LabelTop</returns>
+  static member inline LT x =
+    LabelTop.LabelTop x
+    |> LabelElement.LabelTop
+
+  /// <summary>
+  /// Media Type (^MT)
+  /// </summary>
+  /// <param name="m">Media type (ThermalTransfer or DirectThermal)</param>
+  /// <returns>LabelElement.MediaType</returns>
+  static member inline MT m = LabelElement.MediaType m
 
   static member inline Collection lst = LabelElement.Collection lst
 

--- a/Label.fs
+++ b/Label.fs
@@ -128,6 +128,33 @@ module internal Render =
                 | MediaType mt ->
                     sb.AppendLine(mt.ToString()) |> ignore
                     loop tail sb
+                | Plessey bp ->
+                    sb.AppendLine(bp.ToString()) |> ignore
+                    loop tail sb
+                | Codabar bk ->
+                    sb.AppendLine(bk.ToString()) |> ignore
+                    loop tail sb
+                | Aztec bo ->
+                    sb.AppendLine(bo.ToString()) |> ignore
+                    loop tail sb
+                | GraphicSymbol gs ->
+                    sb.AppendLine(gs.ToString()) |> ignore
+                    loop tail sb
+                | FieldNumber fn ->
+                    sb.AppendLine(fn.ToString()) |> ignore
+                    loop tail sb
+                | FieldParameter fp ->
+                    sb.AppendLine(fp.ToString()) |> ignore
+                    loop tail sb
+                | PrintMirror pm ->
+                    sb.AppendLine(pm.ToString()) |> ignore
+                    loop tail sb
+                | Slew pf ->
+                    sb.AppendLine(pf.ToString()) |> ignore
+                    loop tail sb
+                | LabelReverse lr ->
+                    sb.AppendLine(lr.ToString()) |> ignore
+                    loop tail sb
                 | Collection co ->
                     loop (List.append co tail) sb
 
@@ -730,6 +757,142 @@ type Label =
   /// <param name="m">Media type (ThermalTransfer or DirectThermal)</param>
   /// <returns>LabelElement.MediaType</returns>
   static member inline MT m = LabelElement.MediaType m
+
+  /// <summary>
+  /// Plessey Bar Code (^BP)
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="e">Print check digit</param>
+  /// <param name="h">Bar code height (in dots)</param>
+  /// <param name="f">Print interpretation line</param>
+  /// <param name="g">Print interpretation line above code</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.Plessey</returns>
+  static member inline BP o e h f g (fd: string) =
+    { Plessey.Orientation = o
+      PrintCheckDigit = e
+      Height = h
+      PrintInterpretationLine = f
+      PrintInterpretationLineAboveCode = g
+      Data = FieldData.FieldData fd }
+    |> LabelElement.Plessey
+
+  /// <summary>
+  /// ANSI Codabar Bar Code (^BK)
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="e">Check digit (must be N for Codabar)</param>
+  /// <param name="h">Bar code height (in dots)</param>
+  /// <param name="f">Print interpretation line</param>
+  /// <param name="g">Print interpretation line above code</param>
+  /// <param name="k">Start character (A, B, C or D)</param>
+  /// <param name="n">Stop character (A, B, C or D)</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.Codabar</returns>
+  static member inline BK o e h f g k n (fd: string) =
+    { Codabar.Orientation = o
+      CheckDigit = e
+      Height = h
+      PrintInterpretationLine = f
+      PrintInterpretationLineAboveCode = g
+      StartCharacter = k
+      StopCharacter = n
+      Data = FieldData.FieldData fd }
+    |> LabelElement.Codabar
+
+  /// <summary>
+  /// Aztec Bar Code (^BO)
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="m">Magnification factor. Values: 1 to 10</param>
+  /// <param name="c">Extended Channel Interpretation code indicator</param>
+  /// <param name="d">Error control / symbol size. Values: 0 = default, 1-99 = error correction %, 101-104 = compact, 201-232 = full range, 300 = rune</param>
+  /// <param name="e">Menu symbol</param>
+  /// <param name="n">Number of symbols for structured append. Values: 1 to 26</param>
+  /// <param name="fd">Field Data</param>
+  /// <returns>LabelElement.Aztec</returns>
+  static member inline BO o m c d e n (fd: string) =
+    { Aztec.Orientation = o
+      Magnification = m
+      ExtendedChannel = c
+      ErrorControl = d
+      MenuSymbol = e
+      SymbolCount = n
+      Data = FieldData.FieldData fd }
+    |> LabelElement.Aztec
+
+  /// <summary>
+  /// Graphic Symbol (^GS)
+  ///
+  /// Selects a built-in symbol; the symbol characters (A-E) are supplied
+  /// via the following ^FD.
+  /// </summary>
+  /// <param name="o">Orientation</param>
+  /// <param name="h">Symbol height (in dots)</param>
+  /// <param name="w">Symbol width (in dots)</param>
+  /// <param name="fd">Field Data (symbol selector characters)</param>
+  /// <returns>LabelElement.GraphicSymbol</returns>
+  static member inline GS o h w (fd: string) =
+    { GraphicSymbol.Orientation = o
+      Height = h
+      Width = w
+      Data = FieldData.FieldData fd }
+    |> LabelElement.GraphicSymbol
+
+  /// <summary>
+  /// Field Number (^FN)
+  ///
+  /// Numbers a field for use with stored formats (^XF) or variable data.
+  /// </summary>
+  /// <param name="n">Field number</param>
+  /// <returns>LabelElement.FieldNumber</returns>
+  static member inline FN n =
+    FieldNumber.FieldNumber n
+    |> LabelElement.FieldNumber
+
+  /// <summary>
+  /// Field Parameter (^FP)
+  ///
+  /// Sets the field direction and inter-character gap for the field.
+  /// </summary>
+  /// <param name="d">Field direction (H = horizontal, V = vertical, R = reverse)</param>
+  /// <param name="g">Additional inter-character gap (in dots)</param>
+  /// <returns>LabelElement.FieldParameter</returns>
+  static member inline FP d g =
+    { FieldParameter.Direction = d; Gap = g }
+    |> LabelElement.FieldParameter
+
+  /// <summary>
+  /// Print Mirror Image (^PM)
+  /// </summary>
+  /// <param name="y">Mirror the entire label</param>
+  /// <returns>LabelElement.PrintMirror</returns>
+  static member inline PM y =
+    PrintMirror.PrintMirror y
+    |> LabelElement.PrintMirror
+
+  /// <summary>
+  /// Slew given number of dots (^PF)
+  ///
+  /// Advances the label a given number of dots without printing.
+  /// </summary>
+  /// <param name="n">Number of dots to slew</param>
+  /// <returns>LabelElement.Slew</returns>
+  static member inline PF n =
+    Slew.Slew n
+    |> LabelElement.Slew
+
+  /// <summary>
+  /// Label Reverse Print (^LR)
+  ///
+  /// Reverses the print of the whole label (black on white becomes white
+  /// on black).
+  /// </summary>
+  /// <param name="y">Enable label reverse print</param>
+  /// <returns>LabelElement.LabelReverse</returns>
+  static member inline LR y =
+    LabelReverse.LabelReverse y
+    |> LabelElement.LabelReverse
 
   static member inline Collection lst = LabelElement.Collection lst
 

--- a/Types.fs
+++ b/Types.fs
@@ -524,6 +524,100 @@ type MediaType =
         | MediaType.ThermalTransfer -> "^MTT"
         | MediaType.DirectThermal -> "^MTD"
 
+/// Field direction for the Field Parameter (^FP) command.
+[<RequireQualifiedAccess>]
+type FieldDirection =
+    /// Horizontal
+    | H
+    /// Vertical
+    | V
+    /// Reverse
+    | R
+    override x.ToString() =
+        match x with
+        | FieldDirection.H -> "H"
+        | FieldDirection.V -> "V"
+        | FieldDirection.R -> "R"
+
+/// Plessey Bar Code (^BP)
+type Plessey =
+    { Orientation: Orientation
+      PrintCheckDigit: YesNo
+      Height: int
+      PrintInterpretationLine: YesNo
+      PrintInterpretationLineAboveCode: YesNo
+      Data: FieldData }
+    override x.ToString() =
+        $"^BP{x.Orientation},{x.PrintCheckDigit},{x.Height},{x.PrintInterpretationLine},{x.PrintInterpretationLineAboveCode}{x.Data}"
+
+/// ANSI Codabar Bar Code (^BK)
+type Codabar =
+    { Orientation: Orientation
+      CheckDigit: YesNo
+      Height: int
+      PrintInterpretationLine: YesNo
+      PrintInterpretationLineAboveCode: YesNo
+      StartCharacter: char
+      StopCharacter: char
+      Data: FieldData }
+    override x.ToString() =
+        $"^BK{x.Orientation},{x.CheckDigit},{x.Height},{x.PrintInterpretationLine},{x.PrintInterpretationLineAboveCode},{x.StartCharacter},{x.StopCharacter}{x.Data}"
+
+/// Aztec Bar Code (^BO)
+type Aztec =
+    { Orientation: Orientation
+      Magnification: int
+      ExtendedChannel: YesNo
+      ErrorControl: int
+      MenuSymbol: YesNo
+      SymbolCount: int
+      Data: FieldData }
+    override x.ToString() =
+        $"^BO{x.Orientation},{x.Magnification},{x.ExtendedChannel},{x.ErrorControl},{x.MenuSymbol},{x.SymbolCount}{x.Data}"
+
+/// Graphic Symbol (^GS)
+type GraphicSymbol =
+    { Orientation: Orientation
+      Height: int
+      Width: int
+      Data: FieldData }
+    override x.ToString() =
+        $"^GS{x.Orientation},{x.Height},{x.Width}{x.Data}"
+
+/// Field Number (^FN)
+type FieldNumber =
+    | FieldNumber of int
+    override x.ToString() =
+        let (FieldNumber n) = x
+        $"^FN{n}"
+
+/// Field Parameter (^FP)
+type FieldParameter =
+    { Direction: FieldDirection
+      Gap: int }
+    override x.ToString() = $"^FP{x.Direction},{x.Gap}"
+
+/// Print Mirror Image (^PM)
+type PrintMirror =
+    | PrintMirror of YesNo
+    override x.ToString() =
+        let (PrintMirror y) = x
+        $"^PM{y}"
+
+/// Slew given number of dots (^PF)
+type Slew =
+    | Slew of int
+    override x.ToString() =
+        let (Slew n) = x
+        $"^PF{n}"
+
+/// Label Reverse Print (^LR)
+type LabelReverse =
+    | LabelReverse of YesNo
+    override x.ToString() =
+        let (LabelReverse y) = x
+        $"^LR{y}"
+
 /// A label element/command.
 /// Used for containing all label commands within a single collection/label.
 type LabelElement =
@@ -566,4 +660,13 @@ type LabelElement =
     | LabelShift of LabelShift
     | LabelTop of LabelTop
     | MediaType of MediaType
+    | Plessey of Plessey
+    | Codabar of Codabar
+    | Aztec of Aztec
+    | GraphicSymbol of GraphicSymbol
+    | FieldNumber of FieldNumber
+    | FieldParameter of FieldParameter
+    | PrintMirror of PrintMirror
+    | Slew of Slew
+    | LabelReverse of LabelReverse
     | Collection of LabelElement list

--- a/Types.fs
+++ b/Types.fs
@@ -409,6 +409,121 @@ type UpcA =
     override x.ToString() =
         $"^BU{x.Orientation},{x.Height},{x.PrintInterpretationLine},{x.PrintInterpretationLineAboveCode},{x.PrintCheckDigit}{x.Data}"
 
+/// EAN-8 Bar Code (^B8)
+type Ean8 =
+    { Orientation: Orientation
+      Height: int
+      PrintInterpretationLine: YesNo
+      PrintInterpretationLineAboveCode: YesNo
+      Data: FieldData }
+    override x.ToString() =
+        $"^B8{x.Orientation},{x.Height},{x.PrintInterpretationLine},{x.PrintInterpretationLineAboveCode}{x.Data}"
+
+/// UPC-E Bar Code (^B9)
+type UpcE =
+    { Orientation: Orientation
+      Height: int
+      PrintInterpretationLine: YesNo
+      PrintInterpretationLineAboveCode: YesNo
+      PrintCheckDigit: YesNo
+      Data: FieldData }
+    override x.ToString() =
+        $"^B9{x.Orientation},{x.Height},{x.PrintInterpretationLine},{x.PrintInterpretationLineAboveCode},{x.PrintCheckDigit}{x.Data}"
+
+/// Code 93 Bar Code (^BA)
+type Code93 =
+    { Orientation: Orientation
+      Height: int
+      PrintInterpretationLine: YesNo
+      PrintInterpretationLineAboveCode: YesNo
+      PrintCheckDigit: YesNo
+      Data: FieldData }
+    override x.ToString() =
+        $"^BA{x.Orientation},{x.Height},{x.PrintInterpretationLine},{x.PrintInterpretationLineAboveCode},{x.PrintCheckDigit}{x.Data}"
+
+/// Code 11 Bar Code (^B1)
+type Code11 =
+    { Orientation: Orientation
+      CheckDigit: YesNo
+      Height: int
+      PrintInterpretationLine: YesNo
+      PrintInterpretationLineAboveCode: YesNo
+      Data: FieldData }
+    override x.ToString() =
+        $"^B1{x.Orientation},{x.CheckDigit},{x.Height},{x.PrintInterpretationLine},{x.PrintInterpretationLineAboveCode}{x.Data}"
+
+/// PDF417 Bar Code (^B7)
+type Pdf417 =
+    { Orientation: Orientation
+      Height: int
+      SecurityLevel: int
+      Columns: int
+      Rows: int
+      Truncate: YesNo
+      Data: FieldData }
+    override x.ToString() =
+        $"^B7{x.Orientation},{x.Height},{x.SecurityLevel},{x.Columns},{x.Rows},{x.Truncate}{x.Data}"
+
+/// Field Typeset (^FT)
+/// Like ^FO but positions the field relative to a typeset baseline.
+type FieldTypeset =
+    { X_Axis: int
+      Y_Axis: int
+      Z: Justification }
+    override x.ToString() = $"^FT{x.X_Axis},{x.Y_Axis},{x.Z}"
+
+/// Field Variable (^FV)
+type FieldVariable =
+    | FieldVariable of string
+    override x.ToString() =
+        let (FieldVariable str) = x
+        $"^FV{str}^FS"
+
+/// Field Orientation default (^FW)
+type FieldOrientation =
+    | FieldOrientation of Orientation
+    override x.ToString() =
+        let (FieldOrientation o) = x
+        $"^FW{o}"
+
+/// Print Orientation (^PO)
+[<RequireQualifiedAccess>]
+type PrintOrientation =
+    /// Normal
+    | Normal
+    /// Invert 180 degrees
+    | Invert
+    override x.ToString() =
+        match x with
+        | PrintOrientation.Normal -> "^PON"
+        | PrintOrientation.Invert -> "^POI"
+
+/// Label Shift (^LS)
+type LabelShift =
+    | LabelShift of int
+    override x.ToString() =
+        let (LabelShift n) = x
+        $"^LS{n}"
+
+/// Label Top (^LT)
+type LabelTop =
+    | LabelTop of int
+    override x.ToString() =
+        let (LabelTop n) = x
+        $"^LT{n}"
+
+/// Media Type (^MT)
+[<RequireQualifiedAccess>]
+type MediaType =
+    /// Thermal transfer
+    | ThermalTransfer
+    /// Direct thermal
+    | DirectThermal
+    override x.ToString() =
+        match x with
+        | MediaType.ThermalTransfer -> "^MTT"
+        | MediaType.DirectThermal -> "^MTD"
+
 /// A label element/command.
 /// Used for containing all label commands within a single collection/label.
 type LabelElement =
@@ -439,4 +554,16 @@ type LabelElement =
     | Interleaved2of5 of Interleaved2of5
     | Ean13 of Ean13
     | UpcA of UpcA
+    | Ean8 of Ean8
+    | UpcE of UpcE
+    | Code93 of Code93
+    | Code11 of Code11
+    | Pdf417 of Pdf417
+    | FieldTypeset of FieldTypeset
+    | FieldVariable of FieldVariable
+    | FieldOrientation of FieldOrientation
+    | PrintOrientation of PrintOrientation
+    | LabelShift of LabelShift
+    | LabelTop of LabelTop
+    | MediaType of MediaType
     | Collection of LabelElement list

--- a/tests/Fabra.Tests/GoldenTests.fs
+++ b/tests/Fabra.Tests/GoldenTests.fs
@@ -152,3 +152,51 @@ module GoldenTests =
     [<Fact>]
     let ``^BU renders a UPC-A barcode`` () =
         Assert.Contains("^BUN,100,Y,N,Y^FD12345678901^FS", ZPL.render (Label [ Label.BU Orientation.N 100 YesNo.Y YesNo.N YesNo.Y "12345678901" ]))
+
+    [<Fact>]
+    let ``^B8 renders an EAN-8 barcode`` () =
+        Assert.Contains("^B8N,50,Y,N^FD1234567^FS", ZPL.render (Label [ Label.B8 Orientation.N 50 YesNo.Y YesNo.N "1234567" ]))
+
+    [<Fact>]
+    let ``^B9 renders a UPC-E barcode`` () =
+        Assert.Contains("^B9N,50,Y,N,Y^FD123456^FS", ZPL.render (Label [ Label.B9 Orientation.N 50 YesNo.Y YesNo.N YesNo.Y "123456" ]))
+
+    [<Fact>]
+    let ``^BA renders a Code 93 barcode`` () =
+        Assert.Contains("^BAN,50,Y,N,N^FDCODE93^FS", ZPL.render (Label [ Label.BA Orientation.N 50 YesNo.Y YesNo.N YesNo.N "CODE93" ]))
+
+    [<Fact>]
+    let ``^B1 renders a Code 11 barcode`` () =
+        Assert.Contains("^B1N,N,50,Y,N^FD12345^FS", ZPL.render (Label [ Label.B1 Orientation.N YesNo.N 50 YesNo.Y YesNo.N "12345" ]))
+
+    [<Fact>]
+    let ``^B7 renders a PDF417 barcode`` () =
+        Assert.Contains("^B7N,10,5,2,10,N^FDDATA^FS", ZPL.render (Label [ Label.B7 Orientation.N 10 5 2 10 YesNo.N "DATA" ]))
+
+    [<Fact>]
+    let ``^FT renders a field typeset origin`` () =
+        Assert.Contains("^FT50,100,0", ZPL.render (Label [ Label.FT 50 100 Left ]))
+
+    [<Fact>]
+    let ``^FV renders a field variable`` () =
+        Assert.Contains("^FVvar^FS", ZPL.render (Label [ Label.FV "var" ]))
+
+    [<Fact>]
+    let ``^FW sets the default field orientation`` () =
+        Assert.Contains("^FWR", ZPL.render (Label [ Label.FW Orientation.R ]))
+
+    [<Fact>]
+    let ``^PO inverts the print orientation`` () =
+        Assert.Contains("^POI", ZPL.render (Label [ Label.PO PrintOrientation.Invert ]))
+
+    [<Fact>]
+    let ``^LS sets the label shift`` () =
+        Assert.Contains("^LS10", ZPL.render (Label [ Label.LS 10 ]))
+
+    [<Fact>]
+    let ``^LT sets the label top`` () =
+        Assert.Contains("^LT12", ZPL.render (Label [ Label.LT 12 ]))
+
+    [<Fact>]
+    let ``^MT sets the media type`` () =
+        Assert.Contains("^MTD", ZPL.render (Label [ Label.MT MediaType.DirectThermal ]))

--- a/tests/Fabra.Tests/GoldenTests.fs
+++ b/tests/Fabra.Tests/GoldenTests.fs
@@ -200,3 +200,39 @@ module GoldenTests =
     [<Fact>]
     let ``^MT sets the media type`` () =
         Assert.Contains("^MTD", ZPL.render (Label [ Label.MT MediaType.DirectThermal ]))
+
+    [<Fact>]
+    let ``^BP renders a Plessey barcode`` () =
+        Assert.Contains("^BPN,N,100,Y,N^FD1234^FS", ZPL.render (Label [ Label.BP Orientation.N YesNo.N 100 YesNo.Y YesNo.N "1234" ]))
+
+    [<Fact>]
+    let ``^BK renders an ANSI Codabar barcode`` () =
+        Assert.Contains("^BKN,N,100,Y,N,A,B^FD1234^FS", ZPL.render (Label [ Label.BK Orientation.N YesNo.N 100 YesNo.Y YesNo.N 'A' 'B' "1234" ]))
+
+    [<Fact>]
+    let ``^BO renders an Aztec barcode`` () =
+        Assert.Contains("^BON,5,N,0,N,1^FDAZTEC^FS", ZPL.render (Label [ Label.BO Orientation.N 5 YesNo.N 0 YesNo.N 1 "AZTEC" ]))
+
+    [<Fact>]
+    let ``^GS renders a graphic symbol`` () =
+        Assert.Contains("^GSN,50,50^FDA^FS", ZPL.render (Label [ Label.GS Orientation.N 50 50 "A" ]))
+
+    [<Fact>]
+    let ``^FN renders a field number`` () =
+        Assert.Contains("^FN1", ZPL.render (Label [ Label.FN 1 ]))
+
+    [<Fact>]
+    let ``^FP sets the field parameter`` () =
+        Assert.Contains("^FPH,5", ZPL.render (Label [ Label.FP FieldDirection.H 5 ]))
+
+    [<Fact>]
+    let ``^PM mirrors the print`` () =
+        Assert.Contains("^PMY", ZPL.render (Label [ Label.PM YesNo.Y ]))
+
+    [<Fact>]
+    let ``^PF slews the label`` () =
+        Assert.Contains("^PF24", ZPL.render (Label [ Label.PF 24 ]))
+
+    [<Fact>]
+    let ``^LR reverses the label print`` () =
+        Assert.Contains("^LRY", ZPL.render (Label [ Label.LR YesNo.Y ]))


### PR DESCRIPTION
## Summary

Continues the ZPL command build-out with **21 commands across two batches**, all following the established positional factory pattern (domain type → `LabelElement` case → `Label.*` factory → render branch → test).

### Batch 1

| Family | Commands |
|--------|----------|
| Bar codes | `^B8` EAN-8, `^B9` UPC-E, `^BA` Code 93, `^B1` Code 11, `^B7` PDF417 |
| Fields | `^FT` Field Typeset, `^FV` Field Variable, `^FW` Field Orientation (default) |
| Printer / label setup | `^PO` Print Orientation, `^LS` Label Shift, `^LT` Label Top, `^MT` Media Type |

### Batch 2

| Family | Commands |
|--------|----------|
| Bar codes | `^BP` Plessey, `^BK` ANSI Codabar, `^BO` Aztec |
| Graphics | `^GS` Graphic Symbol |
| Fields | `^FN` Field Number, `^FP` Field Parameter |
| Printer / label setup | `^PM` Print Mirror, `^PF` Slew, `^LR` Label Reverse Print |

New small enums render their command directly where appropriate: `PrintOrientation` (`^PON`/`^POI`), `MediaType` (`^MTT`/`^MTD`), and `FieldDirection` (`^FP` H/V/R). `^FT` reuses `Justification` like `^FO`.

**Note:** `^FT` shares `^FO`'s record field names (`X_Axis`/`Y_Axis`/`Z`), which made the existing `Label.FO` record construction ambiguous — fixed by qualifying it as `{ FieldOrigin.X_Axis = … }`.

`CLAUDE.md` catalogue updated: all 21 ticked off; implemented count now ~46 of ~200.

## Test plan

- [x] `dotnet build Fabra.sln -c Release` — clean, 0 warnings
- [x] `dotnet test Fabra.sln` — 52/52 passing (21 new rendering tests)
- [x] Existing golden files unchanged

https://claude.ai/code/session_01JgobeBrjaun7YtC31Cg9vN